### PR TITLE
MP-BGP SRv6 VPNv4 (dplane)

### DIFF
--- a/lib/command.c
+++ b/lib/command.c
@@ -152,6 +152,7 @@ const char *node_names[] = {
 	"openfabric",		    // OPENFABRIC_NODE
 	"vrrp",			    /* VRRP_NODE */
 	"bmp",			 /* BMP_NODE */
+	"srv6",			 /* SRV6_NODE */
 };
 /* clang-format on */
 

--- a/lib/command.h
+++ b/lib/command.h
@@ -160,6 +160,7 @@ enum node_type {
 	OPENFABRIC_NODE,	/* OpenFabric router configuration node */
 	VRRP_NODE,		 /* VRRP node */
 	BMP_NODE,		/* BMP config under router bgp */
+	SRV6_NODE,   /* SRv6 config */
 	NODE_TYPE_MAX, /* maximum */
 };
 

--- a/lib/nexthop.c
+++ b/lib/nexthop.c
@@ -36,6 +36,7 @@
 
 DEFINE_MTYPE_STATIC(LIB, NEXTHOP, "Nexthop")
 DEFINE_MTYPE_STATIC(LIB, NH_LABEL, "Nexthop label")
+DEFINE_MTYPE_STATIC(LIB, NH_SEGS, "Nexthop segs")
 
 static int _nexthop_labels_cmp(const struct nexthop *nh1,
 			       const struct nexthop *nh2)
@@ -279,6 +280,16 @@ bool nexthop_same_no_labels(const struct nexthop *nh1,
 		return false;
 
 	return true;
+}
+
+void nexthop_add_segs(struct nexthop *nexthop, int mode,
+		size_t num_segs, struct in6_addr *segs)
+{
+	nexthop->nh_seg6_mode = mode;
+	struct seg6_segs *segs_tmp = XCALLOC(MTYPE_NH_SEGS, sizeof(struct seg6_segs));
+	segs_tmp->num_segs = num_segs;
+	memcpy(segs_tmp->segs, segs, num_segs * sizeof(struct in6_addr));
+	nexthop->nh_seg6_segs = segs_tmp;
 }
 
 /* Update nexthop with label information. */

--- a/lib/nexthop.h
+++ b/lib/nexthop.h
@@ -25,6 +25,7 @@
 
 #include "prefix.h"
 #include "mpls.h"
+#include "seg6.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -45,6 +46,7 @@ enum nexthop_types_t {
 	NEXTHOP_TYPE_IPV6,	 /* IPv6 nexthop.  */
 	NEXTHOP_TYPE_IPV6_IFINDEX, /* IPv6 nexthop with ifindex.  */
 	NEXTHOP_TYPE_BLACKHOLE,    /* Null0 nexthop.  */
+	NEXTHOP_TYPE_ENCAP, /* encap */
 };
 
 enum blackhole_type {
@@ -110,6 +112,10 @@ struct nexthop {
 
 	/* Label(s) associated with this nexthop. */
 	struct mpls_label_stack *nh_label;
+
+	/* seg6 */
+	enum seg6_mode_t nh_seg6_mode;
+	struct seg6_segs *nh_seg6_segs;
 };
 
 struct nexthop *nexthop_new(void);
@@ -120,6 +126,9 @@ void nexthops_free(struct nexthop *nexthop);
 void nexthop_add_labels(struct nexthop *, enum lsp_types_t, uint8_t,
 			mpls_label_t *);
 void nexthop_del_labels(struct nexthop *);
+
+void nexthop_add_segs(struct nexthop *nh, int mode,
+		size_t num_segs, struct in6_addr *segs);
 
 /*
  * Hash a nexthop. Suitable for use with hash tables.

--- a/lib/seg6.h
+++ b/lib/seg6.h
@@ -1,0 +1,59 @@
+/*
+ * SEG6 definitions
+ * Copyright 2019 Hiroki Shirokura
+ *
+ * This file is part of GNU Zebra.
+ *
+ * GNU Zebra is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published
+ * by the Free Software Foundation; either version 2, or (at your
+ * option) any later version.
+ *
+ * GNU Zebra is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef _FRR_SEG6_H
+#define _FRR_SEG6_H
+
+#include <zebra.h>
+#include <arpa/inet.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum seg6_mode_t {
+	INLINE,
+	ENCAP,
+	L2ENCAP,
+};
+
+struct seg6_segs {
+	size_t num_segs;
+	struct in6_addr segs[256];
+};
+
+inline static const char*
+seg6_mode2str(enum seg6_mode_t mode)
+{
+	switch (mode) {
+		case INLINE : return "INLINE";
+		case ENCAP  : return "ENCAP";
+		case L2ENCAP: return "L2ENCAP";
+		default:
+			abort();
+	}
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/lib/zclient.h
+++ b/lib/zclient.h
@@ -178,6 +178,10 @@ typedef enum {
 	ZEBRA_VXLAN_SG_ADD,
 	ZEBRA_VXLAN_SG_DEL,
 	ZEBRA_VXLAN_SG_REPLAY,
+	ZEBRA_SEG6LOCAL_ADD,
+	ZEBRA_SEG6LOCAL_DELETE,
+	ZEBRA_SEG6_ADD,
+	ZEBRA_SEG6_DELETE,
 } zebra_message_types_t;
 
 struct redist_proto {
@@ -432,6 +436,63 @@ struct zapi_pw_status {
 	ifindex_t ifindex;
 	uint32_t status;
 };
+
+struct zapi_seg6local {
+	uint32_t action;
+	uint32_t plen;
+	struct in6_addr sid;
+
+	struct in_addr nh4;
+	struct in6_addr nh6;
+	uint32_t table;
+};
+
+static inline void
+zapi_seg6local_dump(FILE *fp, const struct zapi_seg6local *api)
+{
+	char sid_str[128], nh4_str[128], nh6_str[128];
+	inet_ntop(AF_INET6, &api->sid, sid_str, 128);
+	inet_ntop(AF_INET6, &api->nh6, nh6_str, 128);
+	inet_ntop(AF_INET, &api->nh4, nh4_str, 128);
+	fprintf(fp, "zapi_seg6local.action  : %u\n", api->action);
+	fprintf(fp, "zapi_seg6local.sid/plen: %s/%u\n", sid_str, api->plen);
+	fprintf(fp, "zapi_seg6local.nh4     : %s\n", nh4_str);
+	fprintf(fp, "zapi_seg6local.nh6     : %s\n", nh6_str);
+	fprintf(fp, "zapi_seg6local.table   : %u\n", api->table);
+}
+
+struct zapi_seg6 {
+	int32_t afi;
+	struct in_addr pref4;
+	struct in6_addr pref6;
+	uint32_t plen;
+
+	uint32_t mode; /* enum seg6_mode_t */
+	uint32_t num_segs;
+	struct in6_addr segs[16];
+};
+
+static inline void
+zapi_seg6_dump(FILE *fp, const struct zapi_seg6 *api)
+{
+	char pref4_[128], pref6_[128];
+	inet_ntop(AF_INET, &api->pref4, pref4_, 128);
+	inet_ntop(AF_INET6, &api->pref6, pref6_, 128);
+
+	fprintf(fp, "zapi_seg6.afi  : %d\n", api->afi);
+	fprintf(fp, "zapi_seg6.pref4: %s\n", pref4_);
+	fprintf(fp, "zapi_seg6.pref6: %s\n", pref6_);
+	fprintf(fp, "zapi_seg6.plen: %u\n", api->plen);
+
+	fprintf(fp, "zapi_seg6.plen: %s(%u)\n", seg6_mode2str(api->mode), api->mode);
+	fprintf(fp, "zapi_seg6.num_segs: %u\n", api->num_segs);
+
+	for (size_t i=0; i<api->num_segs; i++) {
+		char str[128];
+		inet_ntop(AF_INET6, &api->segs[i], str, 128);
+	  fprintf(fp, "zapi_seg6.segs[%zd]: %s\n", i, str);
+	}
+}
 
 enum zapi_route_notify_owner {
 	ZAPI_ROUTE_FAIL_INSTALL,

--- a/staticd/static_main.c
+++ b/staticd/static_main.c
@@ -142,6 +142,7 @@ int main(int argc, char **argv, char **envp)
 
 	access_list_init();
 	static_vrf_init();
+	static_seg6local_init();
 
 	static_zebra_init();
 	static_vty_init();

--- a/staticd/static_vrf.c
+++ b/staticd/static_vrf.c
@@ -197,6 +197,10 @@ int static_vrf_has_config(struct static_vrf *svrf)
 	return 0;
 }
 
+void static_seg6local_init(void)
+{
+}
+
 void static_vrf_init(void)
 {
 	vrf_init(static_vrf_new, static_vrf_enable,

--- a/staticd/static_vrf.h
+++ b/staticd/static_vrf.h
@@ -32,6 +32,7 @@ struct static_vrf *static_vrf_lookup_by_id(vrf_id_t vrf_id);
 int static_vrf_has_config(struct static_vrf *svrf);
 
 void static_vrf_init(void);
+void static_seg6local_init(void);
 
 struct route_table *static_vrf_static_table(afi_t afi, safi_t safi,
 					    struct static_vrf *svrf);

--- a/staticd/static_vty.c
+++ b/staticd/static_vty.c
@@ -27,14 +27,26 @@
 #include "table.h"
 #include "srcdest_table.h"
 #include "mpls.h"
+#include "seg6.h"
 
 #include "static_vrf.h"
 #include "static_memory.h"
 #include "static_vty.h"
 #include "static_routes.h"
+#include "static_zebra.h"
 #ifndef VTYSH_EXTRACT_PL
 #include "staticd/static_vty_clippy.c"
 #endif
+
+#include "zebra/slankdev_netlink.h"
+
+#include <netinet/in.h>
+#include <linux/seg6_genl.h>
+#include <linux/seg6_hmac.h>
+#include <linux/seg6_iptunnel.h>
+#include <linux/seg6_local.h>
+#include <linux/lwtunnel.h>
+
 static struct static_vrf *static_vty_get_unknown_vrf(struct vty *vty,
 						     const char *vrf_name)
 {
@@ -1036,6 +1048,97 @@ DEFPY(ip_route,
 		table_str, false);
 }
 
+DEFPY(ip_route_encap_seg6,
+      ip_route_encap_seg6_cmd,
+      "[no] ip route <A.B.C.D/M$prefix> encap seg6 mode <encap|insert>$mode_str segs WORD$segs_str",
+      NO_STR IP_STR
+      "Establish static routes\n"
+      "IP destination prefix (e.g. 10.0.0.0/8)\n"
+      "Encap type (SRv6-Transit or SRv6-End)\n"
+      "Encap type (SRv6-Transit)\n"
+			"Specify Mode\n"
+			"T.Encaps Mode\n"
+			"T.Insert Mode\n"
+      "Specify segs\n"
+      "Specify segs\n")
+{
+	bool is_negate = strcmp(argv[0]->arg, "no") == 0;
+	/* char str[128]; */
+	/* prefix2str(prefix, str, sizeof(str)); */
+	//vty_out(vty, "%s prefix=%s mode=%s segs=%s\n", __func__, str, mode_str, segs_str);
+
+	enum seg6_mode_t mode = 0;
+	if (strcmp(mode_str, "encap") == 0) mode = ENCAP;
+	else if (strcmp(mode_str, "insert") == 0) mode = INLINE;
+	else assert(false);
+
+	size_t num_segs = 1;
+	struct in6_addr segs[100];
+
+	const char *ptr = strtok((char*)segs_str, ",");
+	inet_pton(AF_INET6, ptr, &segs[0]);
+	for ( ; ptr; num_segs ++) {
+		assert(num_segs < 90);
+		ptr = strtok(NULL, ",");
+		if (!ptr)
+			break;
+		inet_pton(AF_INET6, ptr, &segs[num_segs]);
+	}
+
+	vrf_id_t vrf_id = 0;
+	static_zebra_route_adddel_seg6(!is_negate, vrf_id,
+			&prefix->prefix, prefix->prefixlen,
+			mode, num_segs, segs);
+	return CMD_SUCCESS;
+}
+
+DEFPY(ipv6_route_encap_seg6local_end,
+      ipv6_route_encap_seg6local_end_cmd,
+      "[no] ipv6 route X:X::X:X/M$prefix encap seg6local action End",
+      NO_STR
+      IPV6_STR
+      "Establish static routes\n"
+      "IPv6 destination prefix (e.g. 3ffe:506::/32)\n"
+      "Encap type (SRv6-Transit or SRv6-End)\n"
+      "Encap type (SRv6-End)\n"
+			"Specify action\n"
+			"End action\n")
+{
+	bool is_negate = strcmp(argv[0]->arg, "no") == 0;
+
+	vrf_id_t vrf_id = 0;
+	static_zebra_route_adddel_seg6local(!is_negate, vrf_id,
+			&prefix->prefix, prefix->prefixlen, SEG6_LOCAL_ACTION_END,
+			NULL/*nouse*/, NULL/*nouse*/, 0/*nouse*/);
+	return CMD_SUCCESS;
+}
+
+DEFPY(ipv6_route_encap_seg6local_end_dx4,
+      ipv6_route_encap_seg6local_end_dx4_cmd,
+      "[no] ipv6 route X:X::X:X/M$prefix encap seg6local action End_DX4 nh4 A.B.C.D",
+      NO_STR
+      IPV6_STR
+      "Establish static routes\n"
+      "IPv6 destination prefix (e.g. 3ffe:506::/32)\n"
+      "Encap type (SRv6-Transit or SRv6-End)\n"
+      "Encap type (SRv6-End)\n"
+			"Specify action\n"
+			"End.DX4 action\n"
+      "Specifty inet nexthop\n"
+      "Specifty inet nexthop\n")
+{
+	bool is_negate = strcmp(argv[0]->arg, "no") == 0;
+	const char *nh4_str_ = argv[is_negate ? 9 : 8]->arg;
+	struct in_addr nh4_;
+	inet_pton(AF_INET, nh4_str_, &nh4_);
+
+	vrf_id_t vrf_id = 0;
+	static_zebra_route_adddel_seg6local(!is_negate, vrf_id,
+			&prefix->prefix, prefix->prefixlen, SEG6_LOCAL_ACTION_END_DX4,
+			&nh4_, NULL/*nouse*/, 0/*nouse*/);
+	return CMD_SUCCESS;
+}
+
 DEFPY(ip_route_vrf,
       ip_route_vrf_cmd,
       "[no] ip route\
@@ -1462,6 +1565,9 @@ void static_vty_init(void)
 	install_element(VRF_NODE, &ip_route_address_interface_vrf_cmd);
 	install_element(CONFIG_NODE, &ip_route_cmd);
 	install_element(VRF_NODE, &ip_route_vrf_cmd);
+	install_element(CONFIG_NODE, &ip_route_encap_seg6_cmd);
+	install_element(CONFIG_NODE, &ipv6_route_encap_seg6local_end_cmd);
+	install_element(CONFIG_NODE, &ipv6_route_encap_seg6local_end_dx4_cmd);
 
 	install_element(CONFIG_NODE, &ipv6_route_blackhole_cmd);
 	install_element(VRF_NODE, &ipv6_route_blackhole_vrf_cmd);

--- a/staticd/static_zebra.c
+++ b/staticd/static_zebra.c
@@ -18,6 +18,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
  */
 #include <zebra.h>
+#include <linux/seg6_local.h>
 
 #include "thread.h"
 #include "command.h"
@@ -337,6 +338,86 @@ void static_zebra_nht_register(struct route_node *rn,
 	if (zclient_send_rnh(zclient, cmd, &p, false, si->nh_vrf_id) < 0)
 		zlog_warn("%s: Failure to send nexthop to zebra",
 			  __PRETTY_FUNCTION__);
+}
+
+extern void static_zebra_route_adddel_seg6(
+		bool install, vrf_id_t vrf_id,
+		const struct in_addr *prefix, size_t plen,
+		enum seg6_mode_t mode, size_t num_segs, struct in6_addr *segs)
+{
+	struct zapi_seg6 api;
+	memset(&api, 0, sizeof(api));
+
+	api.afi = AF_INET;
+	memcpy(&api.pref4, prefix, sizeof(struct in_addr));
+	api.plen = plen;
+	api.mode = mode;
+	api.num_segs = num_segs;
+	for (size_t i=0; i<api.num_segs; i++)
+		memcpy(&api.segs[i], &segs[i], sizeof(struct in6_addr));
+
+#if 1
+	/* DUMP API structure */
+	zapi_seg6_dump(stdout, &api);
+#endif
+
+	struct stream *s = zclient->obuf;
+	stream_reset(s);
+	zclient_create_header(s, install ?
+			ZEBRA_SEG6_ADD : ZEBRA_SEG6_DELETE,
+			vrf_id);
+
+	stream_putl(s, api.afi);
+	stream_write(s, &api.pref4, sizeof(struct in_addr));
+	stream_write(s, &api.pref6, sizeof(struct in6_addr));
+	stream_putl(s, api.plen);
+	stream_putl(s, api.mode);
+	stream_putl(s, api.num_segs);
+	for (size_t i=0; i<api.num_segs; i++)
+		stream_write(s, &api.segs[i], sizeof(struct in6_addr));
+
+	stream_putw_at(s, 0, stream_get_endp(s));
+	zclient_send_message(zclient);
+}
+
+extern void static_zebra_route_adddel_seg6local(
+		bool install, vrf_id_t vrf_id,
+		const struct in6_addr *pref, uint32_t plen, uint32_t action,
+		const struct in_addr *nh4, const struct in6_addr *nh6,
+		uint32_t table)
+{
+	/* Craft API message */
+	struct zapi_seg6local api;
+	memset(&api, 0, sizeof(api));
+
+	api.action = action;
+	memcpy(&api.sid, pref, sizeof(struct in6_addr));
+	api.plen = plen;
+	if (nh4) memcpy(&api.nh4, nh4, sizeof(struct in_addr));
+	if (nh6) memcpy(&api.nh6, nh6, sizeof(struct in6_addr));
+	api.table = table;
+
+#if 1
+	/* DUMP API structure */
+	zapi_seg6local_dump(stdout, &api);
+#endif
+
+	/* Put API object to stream */
+	struct stream *s = zclient->obuf;
+	stream_reset(s);
+	zclient_create_header(s, install ?
+			ZEBRA_SEG6LOCAL_ADD : ZEBRA_SEG6LOCAL_DELETE,
+			vrf_id);
+
+	stream_putl(s, api.action);
+	stream_putl(s, api.plen);
+	stream_write(s, &api.sid, sizeof(struct in6_addr));
+	stream_write(s, &api.nh4, sizeof(struct in_addr));
+	stream_write(s, &api.nh6, sizeof(struct in6_addr));
+	stream_putl(s, api.table);
+	stream_putw_at(s, 0, stream_get_endp(s));
+
+	zclient_send_message(zclient);
 }
 
 extern void static_zebra_route_add(struct route_node *rn,

--- a/staticd/static_zebra.h
+++ b/staticd/static_zebra.h
@@ -24,6 +24,15 @@ extern struct thread_master *master;
 extern void static_zebra_nht_register(struct route_node *rn,
 				      struct static_route *si, bool reg);
 
+extern void static_zebra_route_adddel_seg6(
+		bool install, vrf_id_t vrf_id,
+		const struct in_addr *prefix, size_t plen,
+		enum seg6_mode_t mode, size_t num_segs, struct in6_addr *segs);
+extern void static_zebra_route_adddel_seg6local(
+		bool install, vrf_id_t vrf_id,
+		const struct in6_addr *pref, uint32_t plen, uint32_t action,
+		const struct in_addr *nh4, const struct in6_addr *nh6,
+		uint32_t table);
 extern void static_zebra_route_add(struct route_node *rn,
 				   struct static_route *si_changed,
 				   vrf_id_t vrf_id, safi_t safi, bool install);

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -1173,6 +1173,10 @@ static char **new_completion(const char *text, int start, int end)
 }
 
 /* Vty node structures. */
+static struct cmd_node srv6_node = {
+	SRV6_NODE, "%s(config-srv6)# ",
+};
+
 static struct cmd_node bgp_node = {
 	BGP_NODE, "%s(config-router)# ",
 };
@@ -1334,6 +1338,14 @@ DEFUNSH(VTYSH_REALLYALL, vtysh_end_all, vtysh_end_all_cmd, "end",
 	"End current mode and change to enable mode\n")
 {
 	return vtysh_end();
+}
+
+DEFUNSH(VTYSH_ZEBRA, segment_routing_ipv6, segment_routing_ipv6_cmd,
+	"segment-routing-ipv6",
+	"Segment-Routing-IPv6 configration\n")
+{
+	vty->node = SRV6_NODE;
+	return CMD_SUCCESS;
 }
 
 DEFUNSH(VTYSH_BGPD, router_bgp, router_bgp_cmd,
@@ -1838,6 +1850,7 @@ static int vtysh_exit(struct vty *vty)
 	case KEYCHAIN_NODE:
 	case BFD_NODE:
 	case RPKI_NODE:
+	case SRV6_NODE:
 		vtysh_execute("end");
 		vtysh_execute("configure");
 		vty->node = CONFIG_NODE;
@@ -1965,6 +1978,14 @@ DEFUNSH(VTYSH_VRF, exit_vrf_config, exit_vrf_config_cmd, "exit-vrf",
 	"Exit from VRF configuration mode\n")
 {
 	if (vty->node == VRF_NODE)
+		vty->node = CONFIG_NODE;
+	return CMD_SUCCESS;
+}
+
+DEFUNSH(VTYSH_ZEBRA, exit_srv6_config, exit_srv6_config_cmd, "exit",
+	"Exit from SRv6 configuration mode\n")
+{
+	if (vty->node == SRV6_NODE)
 		vty->node = CONFIG_NODE;
 	return CMD_SUCCESS;
 }
@@ -3705,6 +3726,7 @@ void vtysh_init_vty(void)
 	cmd_variable_handler_register(vtysh_var_handler);
 
 	/* Install nodes. */
+	install_node(&srv6_node, NULL);
 	install_node(&bgp_node, NULL);
 	install_node(&rip_node, NULL);
 	install_node(&interface_node, NULL);
@@ -3946,6 +3968,7 @@ void vtysh_init_vty(void)
 #endif
 	install_element(CONFIG_NODE, &router_isis_cmd);
 	install_element(CONFIG_NODE, &router_openfabric_cmd);
+	install_element(CONFIG_NODE, &segment_routing_ipv6_cmd);
 	install_element(CONFIG_NODE, &router_bgp_cmd);
 #ifdef KEEP_OLD_VPN_COMMANDS
 	install_element(BGP_NODE, &address_family_vpnv4_cmd);
@@ -3997,6 +4020,7 @@ void vtysh_init_vty(void)
 	install_element(BGP_EVPN_NODE, &bgp_evpn_vni_cmd);
 	install_element(BGP_EVPN_VNI_NODE, &exit_vni_cmd);
 
+	install_element(SRV6_NODE, &exit_srv6_config_cmd);
 	install_element(BGP_VRF_POLICY_NODE, &exit_vrf_policy_cmd);
 	install_element(BGP_VNC_DEFAULTS_NODE, &exit_vnc_config_cmd);
 	install_element(BGP_VNC_NVE_GROUP_NODE, &exit_vnc_config_cmd);

--- a/zebra/ge_netlink.c
+++ b/zebra/ge_netlink.c
@@ -1,0 +1,82 @@
+
+#include "zebra/ge_netlink.h"
+
+#include <netinet/if_ether.h>
+#include <linux/if_bridge.h>
+#include <linux/if_link.h>
+#include <net/if_arp.h>
+#include <linux/sockios.h>
+#include <linux/ethtool.h>
+#include <linux/seg6_genl.h>
+#include <linux/genetlink.h>
+#include <linux/rtnetlink.h>
+#include <linux/netlink.h>
+
+#include <stdio.h>
+#include "vty.h"
+#include "zebra/zserv.h"
+#include "zebra/zebra_ns.h"
+#include "zebra/zebra_vrf.h"
+#include "zebra/rt.h"
+#include "zebra/redistribute.h"
+#include "zebra/interface.h"
+#include "zebra/debug.h"
+#include "zebra/rtadv.h"
+#include "zebra/zebra_ptm.h"
+#include "zebra/zebra_mpls.h"
+#include "zebra/hexdump.h"
+#include "zebra/slankdev_netlink.h"
+
+extern struct zebra_privs_t zserv_privs;
+
+static int ge_netlink_resolve_family(int fd, const char* family_name)
+{
+
+ GENL_REQUEST(req, 1024, GENL_ID_CTRL, 0,
+      2, CTRL_CMD_GETFAMILY, NLM_F_REQUEST);
+  addattrstrz(&req.n, 1024, CTRL_ATTR_FAMILY_NAME, family_name);
+
+  char buf[10000];
+  struct nlmsghdr *answer = (struct nlmsghdr*)buf;
+  if (nl_talk(fd, &req.n, answer, sizeof(buf)) < 0)
+    exit(1);
+
+  int genl_family = -1;
+  memcpy(&req, answer, sizeof(req));
+  int len = req.n.nlmsg_len;
+  if (NLMSG_OK(&req.n, len) ) {
+    struct rtattr *rta[CTRL_ATTR_MAX + 1] = {};
+    int l = req.n.nlmsg_len - NLMSG_LENGTH(sizeof(struct genlmsghdr));
+    parse_rtattr(rta, CTRL_ATTR_MAX, (struct rtattr*)req.buf, l);
+
+    if(rta[CTRL_ATTR_FAMILY_ID]) {
+      uint16_t id = rta_getattr_u16(rta[CTRL_ATTR_FAMILY_ID]);
+      genl_family = id;
+    }
+  }
+	return genl_family;
+}
+
+void ge_netlink_sr_tunsrc_change(struct in6_addr *src)
+{
+	int fd = -1;
+	frr_with_privs(&zserv_privs) {
+		fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_GENERIC);
+		if (fd < 0) {
+			fprintf(stderr, "open_genetlink_socket; error\n");
+			exit(1);
+		}
+
+		int genl_family = ge_netlink_resolve_family(fd, "SEG6");
+		if (genl_family < 0) {
+			fprintf(stderr, "ge_netlink_get_family; error\n");
+			exit(1);
+		}
+		GENL_REQUEST(req, 1024, genl_family, 0, SEG6_GENL_VERSION, SEG6_CMD_SET_TUNSRC, NLM_F_REQUEST);
+		addattr_l(&req.n, sizeof(req), SEG6_ATTR_DST, src, sizeof(struct in6_addr));
+		if (nl_talk(fd, &req.n, NULL, 0) < 0)
+		 exit(1);
+	}
+	close(fd);
+}
+

--- a/zebra/ge_netlink.h
+++ b/zebra/ge_netlink.h
@@ -1,0 +1,57 @@
+/* Header file exported by ge_netlink.c to zebra.
+ * Copyright (C) 2019, Hiroki Shirokura
+ *
+ * This file is part of GNU Zebra.
+ *
+ * GNU Zebra is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * GNU Zebra is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#ifndef _ZEBRA_GE_NETLINK_H
+#define _ZEBRA_GE_NETLINK_H
+
+#include <netinet/in.h>
+#include <linux/seg6_genl.h>
+#include <linux/genetlink.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define GENL_REQUEST(_req, _bufsiz, _family, _hdrsiz, _ver, _cmd, _flags) \
+struct {								\
+	struct nlmsghdr		n;					\
+	struct genlmsghdr	g;					\
+	char			buf[NLMSG_ALIGN(_hdrsiz) + (_bufsiz)];	\
+} _req = {								\
+	.n = {								\
+		.nlmsg_type = (_family),				\
+		.nlmsg_flags = (_flags),				\
+		.nlmsg_len = NLMSG_LENGTH(GENL_HDRLEN + (_hdrsiz)),	\
+	},								\
+	.g = {								\
+		.cmd = (_cmd),						\
+		.version = (_ver),					\
+	},								\
+}
+
+
+extern void ge_netlink_init(void);
+extern void ge_netlink_sr_tunsrc_read(void);
+extern void ge_netlink_sr_tunsrc_change(struct in6_addr *src);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* _ZEBRA_GE_NETLINK_H */

--- a/zebra/hexdump.h
+++ b/zebra/hexdump.h
@@ -1,0 +1,28 @@
+#ifndef _HEXDUMP_H_
+#define _HEXDUMP_H_
+#include <stdio.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+
+inline static void hexdump(FILE* fp, const void *buffer, size_t bufferlen)
+{
+  const uint8_t *data = (const uint8_t*)(buffer); size_t row = 0;
+  while (bufferlen > 0) {
+    fprintf(fp, "%04zx:   ", row);
+    size_t n;
+    if (bufferlen < 16) n = bufferlen;
+    else                n = 16;
+
+    for (size_t i = 0; i < n; i++) { if (i == 8) fprintf(fp, " "); fprintf(fp, " %02x", data[i]); }
+    for (size_t i = n; i < 16; i++) { fprintf(fp, "   "); } fprintf(fp, "   ");
+    for (size_t i = 0; i < n; i++) {
+      if (i == 8) fprintf(fp, "  ");
+      uint8_t c = data[i];
+      if (!(0x20 <= c && c <= 0x7e)) c = '.';
+      fprintf(fp, "%c", c);
+    }
+    fprintf(fp, "\n"); bufferlen -= n; data += n; row  += n;
+  }
+}
+#endif /* _HEXDUMP_H_ */

--- a/zebra/kernel_netlink.c
+++ b/zebra/kernel_netlink.c
@@ -558,6 +558,11 @@ int rta_addattr_l(struct rtattr *rta, unsigned int maxlen, int type,
 	return 0;
 }
 
+int addattrstrz(struct nlmsghdr *n, int maxlen, int type, const char *str)
+{
+	return addattr_l(n, maxlen, type, str, strlen(str)+1);
+}
+
 int addattr16(struct nlmsghdr *n, unsigned int maxlen, int type, uint16_t data)
 {
 	return addattr_l(n, maxlen, type, &data, sizeof(uint16_t));

--- a/zebra/kernel_netlink.h
+++ b/zebra/kernel_netlink.h
@@ -42,6 +42,8 @@ extern int addattr16(struct nlmsghdr *n, unsigned int maxlen, int type,
 		     uint16_t data);
 extern int addattr32(struct nlmsghdr *n, unsigned int maxlen, int type,
 		     int data);
+extern int addattrstrz(struct nlmsghdr *n, int maxlen, int type,
+		    const char *str);
 extern struct rtattr *addattr_nest(struct nlmsghdr *n, int maxlen, int type);
 extern int addattr_nest_end(struct nlmsghdr *n, struct rtattr *nest);
 extern struct rtattr *rta_nest(struct rtattr *rta, int maxlen, int type);

--- a/zebra/main.c
+++ b/zebra/main.c
@@ -54,6 +54,7 @@
 #include "zebra/zebra_rnh.h"
 #include "zebra/zebra_pbr.h"
 #include "zebra/zebra_vxlan.h"
+#include "zebra/zebra_seg6.h"
 
 #if defined(HANDLE_NETLINK_FUZZING)
 #include "zebra/kernel_netlink.h"
@@ -249,6 +250,8 @@ FRR_DAEMON_INFO(
 /* Main startup routine. */
 int main(int argc, char **argv)
 {
+	memset(seg6local_sids, 0, sizeof(seg6local_sids));
+
 	// int batch_mode = 0;
 	char *zserv_path = NULL;
 	char *vrf_default_name_configured = NULL;

--- a/zebra/rib.h
+++ b/zebra/rib.h
@@ -305,6 +305,10 @@ typedef enum {
 	RIB_UPDATE_OTHER
 } rib_update_event_t;
 
+extern struct nexthop *route_entry_nexthop_encap_add(struct route_entry *re,
+						       uint32_t seg6_mode, size_t num_segs, struct in6_addr *segs,
+						       vrf_id_t nh_vrf_id);
+
 extern struct nexthop *route_entry_nexthop_ifindex_add(struct route_entry *re,
 						       ifindex_t ifindex,
 						       vrf_id_t nh_vrf_id);

--- a/zebra/rt_netlink.c
+++ b/zebra/rt_netlink.c
@@ -25,6 +25,7 @@
 #include <net/if_arp.h>
 #include <linux/lwtunnel.h>
 #include <linux/mpls_iptunnel.h>
+#include <linux/seg6_iptunnel.h>
 #include <linux/neighbour.h>
 #include <linux/rtnetlink.h>
 
@@ -293,6 +294,46 @@ static vrf_id_t vrf_lookup_by_table(uint32_t table_id, ns_id_t ns_id)
 }
 
 /**
+ * @parse_encap_seg6() - Parses encapsulated seg6 attributes
+ * @tb:         Pointer to rtattr to look for nested items in.
+ * @mode:       SEG6_IPTUN_MODE_{0:INLINE,1:ENCAP,2:L2ENCAP}
+ * @segs:       segs array in6_addr format sized 256.
+ *
+ * Return:      Number of segs.
+ */
+static int parse_encap_seg6(struct rtattr *tb,
+		uint32_t *mode, struct in6_addr *segs)
+{
+	struct rtattr *tb_encap[200] = {0};
+	netlink_parse_rtattr_nested(tb_encap, 200, tb);
+
+	struct seg6_iptunnel_encap *seg =
+		(struct seg6_iptunnel_encap*)tb_encap[SEG6_IPTUNNEL_SRH]+1;
+	*mode = seg->mode;
+	struct ipv6_sr_hdr *srh = seg->srh;
+#if 0
+	printf("%s:--begin--\n", __func__);
+	printf("mode: %d\n", *mode);
+	printf("srh@%p\n", srh);
+	printf(" - nexthdr      : %u\n", srh->nexthdr      );
+	printf(" - hdrlen       : %u\n", srh->hdrlen       );
+	printf(" - type         : %u\n", srh->type         );
+	printf(" - segments_left: %u\n", srh->segments_left);
+	printf(" - first_segment: %u\n", srh->first_segment);
+	printf(" - flags        : %u\n", srh->flags        );
+	printf(" - tag          : %u\n", srh->tag          );
+	printf("%s:--end--\n", __func__);
+#endif
+	size_t n_segs = srh->hdrlen/2;
+	for (size_t i=0; i<n_segs; i++) {
+		char str[128];
+		inet_ntop(AF_INET6, &srh->segments[i], str, sizeof(str));
+		memcpy(&segs[i], &srh->segments[i], sizeof(struct in6_addr));
+	}
+	return n_segs;
+}
+
+/**
  * @parse_encap_mpls() - Parses encapsulated mpls attributes
  * @tb:         Pointer to rtattr to look for nested items in.
  * @labels:     Pointer to store labels in.
@@ -335,6 +376,7 @@ static int netlink_route_change_read_unicast(struct nlmsghdr *h, ns_id_t ns_id,
 
 	int proto = ZEBRA_ROUTE_KERNEL;
 	int index = 0;
+	int encap = 0;
 	int table;
 	int metric = 0;
 	uint32_t mtu = 0;
@@ -452,6 +494,27 @@ static int netlink_route_change_read_unicast(struct nlmsghdr *h, ns_id_t ns_id,
 		tag = *(uint32_t *)RTA_DATA(tb[RTA_FLOW]);
 #endif
 
+	/* SRv6 */
+	uint32_t seg6_mode = 0; /* 1:encap, 2:insert */
+	uint32_t num_segs = 0;
+	struct in6_addr segs[256];
+	if (tb[RTA_ENCAP] && tb[RTA_ENCAP_TYPE]
+			&& *(uint16_t *)RTA_DATA(tb[RTA_ENCAP_TYPE])
+					 == LWTUNNEL_ENCAP_SEG6) {
+		encap = 1;
+		//printf("%s: encap_srv6 \n", __func__);
+		num_segs =
+			parse_encap_seg6(tb[RTA_ENCAP],
+					&seg6_mode, segs);
+		//printf(" mode: %u\n", seg6_mode);
+		for (size_t i=0; i<num_segs; i++) {
+			char str[128];
+			inet_ntop(AF_INET6, &segs[i], str, sizeof(str));
+			//printf(" segs[%zd]: %s\n", i, str);
+		}
+		//nh.type =  NEXTHOP_TYPE_ENCAP;
+	}
+
 	if (tb[RTA_METRICS]) {
 		struct rtattr *mxrta[RTAX_MAX + 1];
 
@@ -557,7 +620,9 @@ static int netlink_route_change_read_unicast(struct nlmsghdr *h, ns_id_t ns_id,
 			memset(&nh, 0, sizeof(nh));
 
 			if (bh_type == BLACKHOLE_UNSPEC) {
-				if (index && !gate)
+				if (encap)
+					nh.type = NEXTHOP_TYPE_ENCAP;
+				else if (index && !gate)
 					nh.type = NEXTHOP_TYPE_IFINDEX;
 				else if (index && gate)
 					nh.type =
@@ -604,6 +669,9 @@ static int netlink_route_change_read_unicast(struct nlmsghdr *h, ns_id_t ns_id,
 			if (num_labels)
 				nexthop_add_labels(&nh, ZEBRA_LSP_STATIC,
 						   num_labels, labels);
+
+			if (num_segs)
+				nexthop_add_segs(&nh, seg6_mode, num_segs, segs);
 
 			rib_add(afi, SAFI_UNICAST, vrf_id, proto, 0, flags, &p,
 				&src_p, &nh, table, metric, mtu, distance, tag);
@@ -679,7 +747,11 @@ static int netlink_route_change_read_unicast(struct nlmsghdr *h, ns_id_t ns_id,
 
 				if (gate) {
 					if (rtm->rtm_family == AF_INET) {
-						if (index)
+						if (encap)
+							nh = route_entry_nexthop_encap_add(
+								re, seg6_mode, num_segs ,segs,
+								nh_vrf_id);
+						else if (index)
 							nh = route_entry_nexthop_ipv4_ifindex_add(
 								re, gate,
 								prefsrc, index,
@@ -3004,4 +3076,9 @@ int netlink_mpls_multipath(int cmd, struct zebra_dplane_ctx *ctx)
 	return netlink_talk_info(netlink_talk_filter, &req.n,
 				 dplane_ctx_get_ns(ctx), 0);
 }
+
+int netlink_seg6_multipath(int cmd, struct zebra_dplane_ctx *ctx)
+{
+}
+
 #endif /* HAVE_NETLINK */

--- a/zebra/slankdev_netlink.h
+++ b/zebra/slankdev_netlink.h
@@ -1,0 +1,206 @@
+#ifndef _SLANKDEV_NETLINK_H_
+#define _SLANKDEV_NETLINK_H_
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <linux/genetlink.h>
+#include "hexdump.h"
+
+#define GENL_REQUEST(_req, _bufsiz, _family, _hdrsiz, _ver, _cmd, _flags) \
+struct {                                                \
+  struct nlmsghdr    n;                                 \
+  struct genlmsghdr  g;                                 \
+  char buf[NLMSG_ALIGN(_hdrsiz) + (_bufsiz)];           \
+} _req = {                                              \
+  .n = {                                                \
+    .nlmsg_type = (_family),                            \
+    .nlmsg_flags = (_flags),                            \
+    .nlmsg_len = NLMSG_LENGTH(GENL_HDRLEN + (_hdrsiz)), \
+  },                                                    \
+  .g = {                                                \
+    .cmd = (_cmd),                                      \
+    .version = (_ver),                                  \
+  },                                                    \
+}
+
+#ifndef NLMSG_TAIL
+#define NLMSG_TAIL(nmsg) \
+  ((struct rtattr *) (((uint8_t *) (nmsg)) + NLMSG_ALIGN((nmsg)->nlmsg_len)))
+#endif
+
+#define RTA_TAIL(rta) \
+    ((struct rtattr *) (((uint8_t *) (rta)) + \
+            RTA_ALIGN((rta)->rta_len)))
+
+static inline __u8 rta_getattr_u8(const struct rtattr *rta) { return *(__u8 *)RTA_DATA(rta); }
+static inline __u16 rta_getattr_u16(const struct rtattr *rta) { return *(__u16 *)RTA_DATA(rta); }
+static inline __u32 rta_getattr_u32(const struct rtattr *rta) { return *(__u32 *)RTA_DATA(rta); }
+static inline __u64 rta_getattr_u64(const struct rtattr *rta) { return *(__u64 *)RTA_DATA(rta); }
+static inline __s8 rta_getattr_s8(const struct rtattr *rta) { return *(__s8 *)RTA_DATA(rta); }
+static inline __u16 rta_getattr_s16(const struct rtattr *rta) { return *(__s16 *)RTA_DATA(rta); }
+static inline __s32 rta_getattr_s32(const struct rtattr *rta) { return *(__s32 *)RTA_DATA(rta); }
+static inline __s64 rta_getattr_s64(const struct rtattr *rta) { return *(__s64 *)RTA_DATA(rta); }
+static inline const char *rta_getattr_str(const struct rtattr *rta) { return (const char *)RTA_DATA(rta); }
+
+static inline int
+parse_rtattr_flags(struct rtattr *tb[],
+    int max, struct rtattr *rta,
+    int len, unsigned short flags)
+{
+  unsigned short type;
+  memset(tb, 0, sizeof(struct rtattr *) * (max + 1));
+  while (RTA_OK(rta, len)) {
+    type = rta->rta_type & ~flags;
+    if ((type <= max) && (!tb[type]))
+      tb[type] = rta;
+    rta = RTA_NEXT(rta, len);
+  }
+  if (len)
+    fprintf(stderr, "!!!Deficit %d, rta_len=%d\n",
+      len, rta->rta_len);
+  return 0;
+}
+
+static inline int
+parse_rtattr(struct rtattr *tb[],
+    int max, struct rtattr *rta, int len)
+{ return parse_rtattr_flags(tb, max, rta, len, 0); }
+
+#if 1
+static inline int
+addattr_l(struct nlmsghdr *n, int maxlen,
+    int type, const void *data, int alen)
+{
+  int len = RTA_LENGTH(alen);
+  struct rtattr *rta;
+
+  if (NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len) > (size_t)maxlen) {
+    fprintf(stderr,
+      "addattr_l ERROR: message exceeded bound of %d\n",
+      maxlen);
+    return -1;
+  }
+  rta = NLMSG_TAIL(n);
+  rta->rta_type = type;
+  rta->rta_len = len;
+  if (alen)
+    memcpy(RTA_DATA(rta), data, alen);
+  n->nlmsg_len = NLMSG_ALIGN(n->nlmsg_len) + RTA_ALIGN(len);
+  return 0;
+}
+
+static inline int
+addattr(struct nlmsghdr *n, int maxlen, int type)
+{ return addattr_l(n, maxlen, type, NULL, 0); }
+static inline int
+addattr8(struct nlmsghdr *n, int maxlen, int type, __u8 data)
+{ return addattr_l(n, maxlen, type, &data, sizeof(__u8)); }
+static inline int
+addattr16(struct nlmsghdr *n, int maxlen, int type, __u16 data)
+{ return addattr_l(n, maxlen, type, &data, sizeof(__u16)); }
+static inline int
+addattr32(struct nlmsghdr *n, int maxlen, int type, __u32 data)
+{ return addattr_l(n, maxlen, type, &data, sizeof(__u32)); }
+static inline int
+addattr64(struct nlmsghdr *n, int maxlen, int type, __u64 data)
+{ return addattr_l(n, maxlen, type, &data, sizeof(__u64)); }
+static inline int
+addattrstrz(struct nlmsghdr *n, int maxlen, int type, const char *str)
+{ return addattr_l(n, maxlen, type, str, strlen(str)+1); }
+#endif
+
+static inline int
+nl_talk(int fd, struct nlmsghdr *n,
+                struct nlmsghdr *answer, size_t answer_buf_siz)
+{
+  static char buf[10000];
+  if (answer == NULL) {
+    n->nlmsg_flags |= NLM_F_ACK;
+    answer = (struct nlmsghdr*)buf;
+    answer_buf_siz = sizeof(buf);
+  }
+
+  int ret = send(fd, n, n->nlmsg_len, 0);
+  if (ret < 0) {
+    perror("send");
+    exit(1);
+  }
+  ret = recv(fd, answer, answer_buf_siz, 0);
+  if (ret < 0) {
+    perror("recv");
+    exit(1);
+  }
+  return 0;
+}
+
+static inline int
+rta_addattr_l(struct rtattr *rta, int maxlen, int type,
+      const void *data, int alen)
+{
+  struct rtattr *subrta;
+  int len = RTA_LENGTH(alen);
+
+  if (RTA_ALIGN(rta->rta_len) + RTA_ALIGN(len) > (size_t)maxlen) {
+    fprintf(stderr,
+      "rta_addattr_l: Error! max allowed bound %d exceeded\n",
+      maxlen);
+    return -1;
+  }
+  subrta = (struct rtattr *)(((char *)rta) + RTA_ALIGN(rta->rta_len));
+  subrta->rta_type = type;
+  subrta->rta_len = len;
+  if (alen)
+    memcpy(RTA_DATA(subrta), data, alen);
+  rta->rta_len = NLMSG_ALIGN(rta->rta_len) + RTA_ALIGN(len);
+  return 0;
+}
+
+static inline int
+rta_addattr8(struct rtattr *rta, int maxlen, int type, __u8 data)
+{ return rta_addattr_l(rta, maxlen, type, &data, sizeof(__u8)); }
+static inline int
+rta_addattr16(struct rtattr *rta, int maxlen, int type, __u16 data)
+{ return rta_addattr_l(rta, maxlen, type, &data, sizeof(__u16)); }
+static inline int
+rta_addattr32(struct rtattr *rta, int maxlen, int type, __u32 data)
+{ return rta_addattr_l(rta, maxlen, type, &data, sizeof(__u32)); }
+static inline int
+rta_addattr64(struct rtattr *rta, int maxlen, int type, __u64 data)
+{ return rta_addattr_l(rta, maxlen, type, &data, sizeof(__u64)); }
+
+static inline struct rtattr*
+rta_nest(struct rtattr *rta, int maxlen, int type)
+{
+  struct rtattr *nest = RTA_TAIL(rta);
+  rta_addattr_l(rta, maxlen, type, NULL, 0);
+  nest->rta_type |= NLA_F_NESTED;
+  return nest;
+}
+
+static inline int rta_nest_end(struct rtattr *rta, struct rtattr *nest)
+{
+  nest->rta_len = (uint8_t *)RTA_TAIL(rta) - (uint8_t *)nest;
+  return rta->rta_len;
+}
+
+static inline int addraw_l(struct nlmsghdr *n, int maxlen, const void *data, int len)
+{
+  if (NLMSG_ALIGN(n->nlmsg_len) + NLMSG_ALIGN(len) > (size_t)maxlen) {
+    fprintf(stderr,
+      "addraw_l ERROR: message exceeded bound of %d\n",
+      maxlen);
+    return -1;
+  }
+
+  memcpy(NLMSG_TAIL(n), data, len);
+  memset((uint8_t *) NLMSG_TAIL(n) + len, 0, NLMSG_ALIGN(len) - len);
+  n->nlmsg_len = NLMSG_ALIGN(n->nlmsg_len) + NLMSG_ALIGN(len);
+  return 0;
+}
+
+#endif /* _SLANKDEV_NETLINK_H_ */

--- a/zebra/subdir.am
+++ b/zebra/subdir.am
@@ -58,6 +58,7 @@ zebra_zebra_SOURCES = \
 	zebra/redistribute.c \
 	zebra/router-id.c \
 	zebra/rt_netlink.c \
+	zebra/ge_netlink.c \
 	zebra/rt_socket.c \
 	zebra/rtadv.c \
 	zebra/rtread_getmsg.c \
@@ -94,6 +95,7 @@ zebra_zebra_SOURCES = \
 	zebra/table_manager.c \
 	zebra/zapi_msg.c \
 	zebra/zebra_errors.c \
+	zebra/zebra_seg6.c \
 	# end
 
 zebra/debug_clippy.c: $(CLIPPY_DEPS)
@@ -127,6 +129,8 @@ noinst_HEADERS += \
 	zebra/router-id.h \
 	zebra/rt.h \
 	zebra/rt_netlink.h \
+	zebra/ge_netlink.h \
+	zebra/slankdev_netlink.h \
 	zebra/rtadv.h \
 	zebra/rule_netlink.h \
 	zebra/zebra_mlag.h \
@@ -154,6 +158,7 @@ noinst_HEADERS += \
 	zebra/table_manager.h \
 	zebra/zapi_msg.h \
 	zebra/zebra_errors.h \
+	zebra/zebra_seg6.h \
 	# end
 
 zebra_zebra_irdp_la_SOURCES = \

--- a/zebra/zapi_msg.c
+++ b/zebra/zapi_msg.c
@@ -64,6 +64,7 @@
 #include "zebra/zapi_msg.h"
 #include "zebra/zebra_errors.h"
 #include "zebra/zebra_mlag.h"
+#include "zebra/zebra_seg6.h"
 
 /* Encoding helpers -------------------------------------------------------- */
 
@@ -2551,6 +2552,10 @@ void (*zserv_handlers[])(ZAPI_HANDLER_ARGS) = {
 	[ZEBRA_IPTABLE_DELETE] = zread_iptable,
 	[ZEBRA_VXLAN_FLOOD_CONTROL] = zebra_vxlan_flood_control,
 	[ZEBRA_VXLAN_SG_REPLAY] = zebra_vxlan_sg_replay,
+	[ZEBRA_SEG6LOCAL_ADD] = zebra_seg6local_add,
+	[ZEBRA_SEG6LOCAL_DELETE] = zebra_seg6local_delete,
+	[ZEBRA_SEG6_ADD] = zebra_seg6_add,
+	[ZEBRA_SEG6_DELETE] = zebra_seg6_delete,
 };
 
 #if defined(HANDLE_ZAPI_FUZZING)

--- a/zebra/zebra_rib.c
+++ b/zebra/zebra_rib.c
@@ -222,6 +222,27 @@ void route_entry_nexthop_delete(struct route_entry *re, struct nexthop *nexthop)
 	re->nexthop_num--;
 }
 
+struct nexthop *route_entry_nexthop_encap_add(struct route_entry *re,
+						uint32_t seg6_mode, size_t num_segs, struct in6_addr *segs,
+						vrf_id_t nh_vrf_id)
+{
+	struct nexthop *nexthop;
+
+	nexthop = nexthop_new();
+	nexthop->type = NEXTHOP_TYPE_ENCAP;
+
+	nexthop->nh_seg6_mode = seg6_mode;
+	nexthop->nh_seg6_segs->num_segs = num_segs;
+	memcpy(nexthop->nh_seg6_segs->segs, segs, num_segs*sizeof(struct in6_addr));
+
+	//if (num_segs)
+	//	nexthop_add_segs(&nh, seg6_mode, num_segs, segs);
+
+	nexthop->vrf_id = nh_vrf_id;
+	route_entry_nexthop_add(re, nexthop);
+
+	return nexthop;
+}
 
 struct nexthop *route_entry_nexthop_ifindex_add(struct route_entry *re,
 						ifindex_t ifindex,
@@ -2957,6 +2978,9 @@ int rib_add(afi_t afi, safi_t safi, vrf_id_t vrf_id, int type,
 	nexthop = nexthop_new();
 	*nexthop = *nh;
 	route_entry_nexthop_add(re, nexthop);
+
+	//SET_FLAG(re->status, ROUTE_ENTRY_INSTALLED);
+	//SET_FLAG(re->flags, ZEBRA_FLAG_SELECTED);
 
 	return rib_add_multipath(afi, safi, p, src_p, re);
 }

--- a/zebra/zebra_seg6.c
+++ b/zebra/zebra_seg6.c
@@ -1,0 +1,463 @@
+/* BGP message definition header.
+ * Copyright (C) 2019 Hiroki Shirokura
+ *
+ * This file is part of GNU Zebra.
+ *
+ * GNU Zebra is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * GNU Zebra is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#include <zebra.h>
+
+#include "prefix.h"
+#include "stream.h"
+#include "zebra/zserv.h"
+#include "zebra/zebra_seg6.h"
+#include "zebra/slankdev_netlink.h"
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <linux/seg6_iptunnel.h>
+#include <linux/lwtunnel.h>
+#include <linux/seg6_local.h>
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <arpa/inet.h>
+#include <netinet/in.h>
+
+extern struct zebra_privs_t zserv_privs;
+struct seg6local_sid *seg6local_sids[MAX_SEG6LOCAL_SIDS];
+
+static int zapi_seg6local_decode(struct stream *s, struct zapi_seg6local *api)
+{
+	STREAM_GETL(s, api->action);
+	STREAM_GETL(s, api->plen);
+	stream_get(&api->sid, s, 16);
+	stream_get(&api->nh4, s, 4);
+	stream_get(&api->nh6, s, 16);
+	STREAM_GETL(s, api->table);
+stream_failure:
+	return 0;
+}
+
+static int zapi_seg6_decode(struct stream *s, struct zapi_seg6 *api)
+{
+	STREAM_GETL(s, api->afi);
+	stream_get(&api->pref4, s, 4);
+	stream_get(&api->pref6, s, 16);
+	STREAM_GETL(s, api->plen);
+
+	STREAM_GETL(s, api->mode);
+	STREAM_GETL(s, api->num_segs);
+	for (size_t i=0; i<api->num_segs; i++)
+		stream_get(&api->segs[i], s, 16);
+stream_failure:
+	return 0;
+}
+
+static struct ipv6_sr_hdr *parse_srh(bool encap,
+    size_t num_segs, const struct in6_addr *segs)
+{
+  const size_t srhlen = 8 + sizeof(struct in6_addr)*(encap ? num_segs+1 : num_segs);
+
+  struct ipv6_sr_hdr *srh = malloc(srhlen);
+  memset(srh, 0, srhlen);
+  srh->hdrlen = (srhlen >> 3) - 1;
+  srh->type = 4;
+  srh->segments_left = encap ? num_segs : num_segs - 1;
+  srh->first_segment = encap ? num_segs : num_segs - 1;
+
+  size_t srh_idx = encap ? 1 : 0;
+  for (ssize_t i=num_segs-1; i>=0; i--)
+    memcpy(&srh->segments[srh_idx + i], &segs[num_segs - 1 - i], sizeof(struct in6_addr));
+  return srh;
+}
+
+static void adddel_in4_seg6_route(
+    struct in_addr *pref, uint32_t plen, uint32_t mode,
+		uint32_t num_segs, const struct in6_addr *segs,
+    uint32_t oif_idx,
+		bool install)
+{
+  int fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+  if (fd < 0)
+    exit(1);
+
+  struct {
+    struct nlmsghdr  n;
+    struct rtmsg r;
+    char buf[4096];
+  } req = {
+    .n.nlmsg_len = NLMSG_LENGTH(sizeof(struct rtmsg)),
+    .n.nlmsg_flags = NLM_F_REQUEST | NLM_F_CREATE | NLM_F_EXCL | NLM_F_ACK,
+    .n.nlmsg_type = install ? RTM_NEWROUTE : RTM_DELROUTE,
+    .r.rtm_family = AF_INET,
+    .r.rtm_dst_len = plen,
+    .r.rtm_src_len = 0,
+    .r.rtm_tos = 0,
+    .r.rtm_table = RT_TABLE_MAIN,
+    .r.rtm_protocol = 0x03,
+    .r.rtm_scope = 0xfd,
+    .r.rtm_type = RTN_UNICAST,
+    .r.rtm_flags = 0,
+  };
+
+  /* set RTA_DST */
+  addattr_l(&req.n, sizeof(req), RTA_DST, pref, sizeof(struct in_addr));
+  req.r.rtm_dst_len = plen;
+
+  /* set RTA_OIF */
+  addattr32(&req.n, sizeof(req), RTA_OIF, oif_idx);
+
+  /* set RTA_ENCAP */
+  char buf[1024];
+  struct rtattr *rta = (void *)buf;
+  rta->rta_type = RTA_ENCAP;
+  rta->rta_len = RTA_LENGTH(0);
+  struct rtattr *nest = rta_nest(rta, sizeof(buf), RTA_ENCAP);
+  struct ipv6_sr_hdr *srh = parse_srh(false, num_segs, segs);
+  size_t srhlen = (srh->hdrlen + 1) << 3;
+  struct seg6_iptunnel_encap *tuninfo = malloc(sizeof(*tuninfo) + srhlen);
+  memset(tuninfo, 0, sizeof(*tuninfo) + srhlen);
+  memcpy(tuninfo->srh, srh, srhlen);
+  tuninfo->mode = SEG6_IPTUN_MODE_ENCAP;
+  rta_addattr_l(rta, sizeof(buf), SEG6_IPTUNNEL_SRH,
+      tuninfo, sizeof(*tuninfo) + srhlen);
+  rta_nest_end(rta, nest);
+  addraw_l(&req.n, 1024 , RTA_DATA(rta), RTA_PAYLOAD(rta));
+
+  /* set RTA_ENCAP_TYPE */
+  addattr16(&req.n, sizeof(req), RTA_ENCAP_TYPE, LWTUNNEL_ENCAP_SEG6);
+
+  hexdump(stdout, &req.n, req.n.nlmsg_len);
+  if (nl_talk(fd, &req.n, NULL, 0) < 0)
+    exit(1);
+
+  close(fd);
+}
+
+static void add_seg6local_end_route(
+    struct in6_addr *pref, uint32_t plen,
+    uint32_t oif_idx, bool install)
+{
+	int fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+  if (fd < 0)
+    exit(1);
+
+  struct {
+    struct nlmsghdr  n;
+    struct rtmsg r;
+    char buf[4096];
+  } req = {
+    .n.nlmsg_len = NLMSG_LENGTH(sizeof(struct rtmsg)),
+    .n.nlmsg_flags = NLM_F_REQUEST | NLM_F_CREATE | NLM_F_EXCL | NLM_F_ACK,
+    .n.nlmsg_type = install ? RTM_NEWROUTE : RTM_DELROUTE,
+    .r.rtm_family = AF_INET6,
+    .r.rtm_dst_len = plen,
+    .r.rtm_src_len = 0,
+    .r.rtm_tos = 0,
+    .r.rtm_table = RT_TABLE_MAIN,
+    .r.rtm_protocol = 0x03,
+    .r.rtm_scope = 0xfd,
+    .r.rtm_type = RTN_UNICAST,
+    .r.rtm_flags = 0,
+  };
+
+  /* set RTA_DST */
+  addattr_l(&req.n, sizeof(req), RTA_DST, pref, sizeof(struct in6_addr));
+  req.r.rtm_dst_len = plen;
+
+  /* set RTA_OIF */
+  addattr32(&req.n, sizeof(req), RTA_OIF, oif_idx);
+
+  /* set RTA_ENCAP */
+  char buf[1024];
+  struct rtattr *rta = (void *)buf;
+  rta->rta_type = RTA_ENCAP;
+  rta->rta_len = RTA_LENGTH(0);
+  struct rtattr *nest = rta_nest(rta, sizeof(buf), RTA_ENCAP);
+  rta_addattr32(rta, sizeof(buf), SEG6_LOCAL_ACTION, SEG6_LOCAL_ACTION_END);
+  rta_nest_end(rta, nest);
+  addraw_l(&req.n, 1024 , RTA_DATA(rta), RTA_PAYLOAD(rta));
+
+  /* set RTA_ENCAP_TYPE */
+  addattr16(&req.n, sizeof(req), RTA_ENCAP_TYPE, LWTUNNEL_ENCAP_SEG6_LOCAL);
+
+  hexdump(stdout, &req.n, req.n.nlmsg_len);
+  if (nl_talk(fd, &req.n, NULL, 0) < 0)
+    exit(1);
+
+	close(fd);
+}
+
+static void add_seg6local_end_dx4_route(
+    struct in6_addr *pref, uint32_t plen,
+    uint32_t oif_idx, struct in_addr *nh4,
+		bool install)
+{
+	int fd = socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE);
+  if (fd < 0)
+    exit(1);
+
+  struct {
+    struct nlmsghdr  n;
+    struct rtmsg r;
+    char buf[4096];
+  } req = {
+    .n.nlmsg_len = NLMSG_LENGTH(sizeof(struct rtmsg)),
+    .n.nlmsg_flags = NLM_F_REQUEST | NLM_F_CREATE | NLM_F_EXCL | NLM_F_ACK,
+    .n.nlmsg_type = install ? RTM_NEWROUTE : RTM_DELROUTE,
+    .r.rtm_family = AF_INET6,
+    .r.rtm_dst_len = plen,
+    .r.rtm_src_len = 0,
+    .r.rtm_tos = 0,
+    .r.rtm_table = RT_TABLE_MAIN,
+    .r.rtm_protocol = 0x03,
+    .r.rtm_scope = 0xfd,
+    .r.rtm_type = RTN_UNICAST,
+    .r.rtm_flags = 0,
+  };
+
+  /* set RTA_DST */
+  addattr_l(&req.n, sizeof(req), RTA_DST, pref, sizeof(struct in6_addr));
+  req.r.rtm_dst_len = plen;
+
+  /* set RTA_OIF */
+  addattr32(&req.n, sizeof(req), RTA_OIF, oif_idx);
+
+  /* set RTA_ENCAP */
+  char buf[1024];
+  struct rtattr *rta = (void *)buf;
+  rta->rta_type = RTA_ENCAP;
+  rta->rta_len = RTA_LENGTH(0);
+  struct rtattr *nest = rta_nest(rta, sizeof(buf), RTA_ENCAP);
+  rta_addattr32(rta, sizeof(buf), SEG6_LOCAL_ACTION, SEG6_LOCAL_ACTION_END_DX4);
+	rta_addattr_l(rta, sizeof(buf), SEG6_LOCAL_NH4, nh4, sizeof(struct in_addr));
+  rta_nest_end(rta, nest);
+  addraw_l(&req.n, 1024 , RTA_DATA(rta), RTA_PAYLOAD(rta));
+
+  /* set RTA_ENCAP_TYPE */
+  addattr16(&req.n, sizeof(req), RTA_ENCAP_TYPE, LWTUNNEL_ENCAP_SEG6_LOCAL);
+
+  hexdump(stdout, &req.n, req.n.nlmsg_len);
+  if (nl_talk(fd, &req.n, NULL, 0) < 0)
+    exit(1);
+
+	close(fd);
+}
+
+const char* seg6local_action2str(uint32_t action)
+{
+	switch (action) {
+	case SEG6_LOCAL_ACTION_END: return "End";
+  case SEG6_LOCAL_ACTION_END_X: return "End.X";
+  case SEG6_LOCAL_ACTION_END_T: return "End.T";
+	case SEG6_LOCAL_ACTION_END_DX2: return "End.DX2";
+  case SEG6_LOCAL_ACTION_END_DX6: return "End.DX6";
+  case SEG6_LOCAL_ACTION_END_DX4: return "End.DX4";
+  case SEG6_LOCAL_ACTION_END_DT6: return "End.DT6";
+  case SEG6_LOCAL_ACTION_END_DT4: return "End.DT4";
+  case SEG6_LOCAL_ACTION_END_B6: return "End.B6";
+	case SEG6_LOCAL_ACTION_END_B6_ENCAP: return "End.B6.Encap";
+	case SEG6_LOCAL_ACTION_END_BM: return "End.BM";
+  case SEG6_LOCAL_ACTION_END_S: return "End.S";
+  case SEG6_LOCAL_ACTION_END_AS: return "End.AS";
+  case SEG6_LOCAL_ACTION_END_AM: return "End.AM";
+
+	case SEG6_LOCAL_ACTION_UNSPEC:
+	default:
+		printf("ABORT...\n");
+		abort();
+	}
+}
+
+int
+snprintf_seg6local_sid(char *str, size_t size,
+		const struct seg6local_sid *sid)
+{
+	char buf[128];
+	inet_ntop(AF_INET6, &sid->sid, buf, sizeof(buf));
+	return snprintf(str, size,
+			"ipv6 route %s/%u encap seg6local action %s",
+			buf, sid->plen, seg6local_action2str(sid->action));
+}
+
+static int add_seg6local_sid(const struct in6_addr *pref,
+		uint32_t plen, uint32_t action, void *args)
+{
+	struct seg6local_sid *sid =
+		(struct seg6local_sid*)malloc(sizeof(struct seg6local_sid));
+	memcpy(&sid->sid, pref, sizeof(struct in6_addr));
+	sid->plen = plen;
+	sid->action = action;
+
+	for (size_t i=0; i<MAX_SEG6LOCAL_SIDS; i++) {
+		if (!seg6local_sids[i])
+			continue;
+
+		if ((seg6local_sids[i]->plen == plen)
+		 && (memcmp(&seg6local_sids[i]->sid, pref, plen) == 0)) {
+			struct seg6local_sid *tmp = seg6local_sids[i];
+			seg6local_sids[i] = sid;
+			free(tmp);
+			return i;
+		}
+	}
+
+	for (size_t i=0; i<MAX_SEG6LOCAL_SIDS; i++) {
+		if (!seg6local_sids[i]) {
+			seg6local_sids[i] = sid;
+			return i;
+		}
+	}
+
+	free(sid);
+	return -1;
+}
+
+static int del_seg6local_sid(const struct in6_addr *pref,
+		uint32_t plen, uint32_t action, void *args)
+{
+	for (size_t i=0; i<MAX_SEG6LOCAL_SIDS; i++) {
+		if (!seg6local_sids[i])
+			continue;
+
+		if ((seg6local_sids[i]->plen == plen)
+		 && (memcmp(&seg6local_sids[i]->sid, pref, plen) == 0)) {
+			struct seg6local_sid *tmp = seg6local_sids[i];
+			free(tmp);
+			return i;
+		}
+	}
+
+	return -1;
+}
+
+size_t num_seg6local_sids(void)
+{
+	size_t num = 0;
+	for (size_t i=0; i<MAX_SEG6LOCAL_SIDS; i++) {
+		if (seg6local_sids[i])
+			num ++;
+	}
+	return num;
+}
+
+void zebra_seg6local_add(ZAPI_HANDLER_ARGS)
+{
+	struct zapi_seg6local api;
+	struct stream *s = msg;
+	memset(&api, 0, sizeof(struct zapi_seg6local));
+	if (zapi_seg6local_decode(s, &api) < 0) {
+		printf("%s: Unable to decode zapi_route sent",
+				 __PRETTY_FUNCTION__);
+		return;
+	}
+
+#if 1
+	/* DUMP API structure */
+	zapi_seg6local_dump(stdout, &api);
+#endif
+
+	const uint32_t dummy_oif = 2;
+	add_seg6local_sid(&api.sid, api.plen, api.action, NULL);
+	frr_with_privs(&zserv_privs) {
+		switch (api.action) {
+			case SEG6_LOCAL_ACTION_END:
+				add_seg6local_end_route(&api.sid, api.plen, dummy_oif, true);
+				break;
+			case SEG6_LOCAL_ACTION_END_DX4:
+				add_seg6local_end_dx4_route(&api.sid, api.plen, dummy_oif, &api.nh4, true);
+				break;
+			default:
+				abort();
+				break;
+		}
+	}
+}
+
+void zebra_seg6local_delete(ZAPI_HANDLER_ARGS)
+{
+	struct zapi_seg6local api;
+	struct stream *s = msg;
+	memset(&api, 0, sizeof(struct zapi_seg6local));
+	if (zapi_seg6local_decode(s, &api) < 0) {
+		printf("%s: Unable to decode zapi_route sent",
+				 __PRETTY_FUNCTION__);
+		return;
+	}
+
+#if 1
+	/* DUMP API structure */
+	zapi_seg6local_dump(stdout, &api);
+#endif
+
+	del_seg6local_sid(&api.sid, api.plen, 0, NULL);
+
+	const uint32_t dummy_oif = 2;
+	frr_with_privs(&zserv_privs) {
+		switch (api.action) {
+			case SEG6_LOCAL_ACTION_END:
+				add_seg6local_end_route(&api.sid, api.plen, dummy_oif, false);
+				break;
+			case SEG6_LOCAL_ACTION_END_DX4:
+				add_seg6local_end_dx4_route(&api.sid, api.plen, dummy_oif, &api.nh4, false);
+				break;
+			default:
+				abort();
+				break;
+		}
+	}
+}
+
+void zebra_seg6_add(ZAPI_HANDLER_ARGS)
+{
+	struct zapi_seg6 api;
+	memset(&api, 0, sizeof(api));
+	zapi_seg6_decode(msg, &api);
+
+#if 1
+	/* DUMP API structure */
+	zapi_seg6_dump(stdout, &api);
+#endif
+
+	const uint32_t dummy_oif = 2;
+	frr_with_privs(&zserv_privs) {
+		adddel_in4_seg6_route(&api.pref4, api.plen, api.mode,
+				api.num_segs, api.segs, dummy_oif, true);
+	}
+}
+
+void zebra_seg6_delete(ZAPI_HANDLER_ARGS)
+{
+	struct zapi_seg6 api;
+	memset(&api, 0, sizeof(api));
+	zapi_seg6_decode(msg, &api);
+
+#if 1
+	/* DUMP API structure */
+	zapi_seg6_dump(stdout, &api);
+#endif
+
+	const uint32_t dummy_oif = 2;
+	frr_with_privs(&zserv_privs) {
+		adddel_in4_seg6_route(&api.pref4, api.plen, api.mode,
+				api.num_segs, api.segs, dummy_oif, false);
+	}
+}
+

--- a/zebra/zebra_seg6.h
+++ b/zebra/zebra_seg6.h
@@ -1,0 +1,62 @@
+/* BGP message definition header.
+ * Copyright (C) 2019 Hiroki Shirokura
+ *
+ * This file is part of GNU Zebra.
+ *
+ * GNU Zebra is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * GNU Zebra is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+
+#ifndef _QUAGGA_ZEBRA_SEG6_H
+#define _QUAGGA_ZEBRA_SEG6_H
+
+#include "qobj.h"
+#include "prefix.h"
+#include <pthread.h>
+
+/* SRv6 instance structure.  */
+struct srv6 {
+	bool is_enable;
+	struct in6_addr encap_src;
+	struct prefix_ipv6 locator;
+
+	QOBJ_FIELDS
+};
+DECLARE_QOBJ_TYPE(srv6)
+
+struct seg6local_sid {
+	struct in6_addr sid;
+	uint32_t plen;
+
+	uint32_t action; /* SEG6_LOCAL_ACTION_{HOGE, END, END_X} */
+};
+
+#define MAX_SEG6LOCAL_SIDS 1024
+extern struct seg6local_sid *seg6local_sids[MAX_SEG6LOCAL_SIDS];
+
+extern const char* seg6local_action2str(uint32_t action);
+extern int snprintf_seg6local_sid(char *str,
+		size_t size, const struct seg6local_sid *sid);
+
+extern size_t num_seg6local_sids(void);
+extern struct srv6 *srv6_get_default(void);
+extern int srv6_config_write(struct vty *);
+
+extern void zebra_seg6local_add(ZAPI_HANDLER_ARGS);
+extern void zebra_seg6local_delete(ZAPI_HANDLER_ARGS);
+extern void zebra_seg6_add(ZAPI_HANDLER_ARGS);
+extern void zebra_seg6_delete(ZAPI_HANDLER_ARGS);
+
+
+#endif /* _QUAGGA_ZEBRA_SEG6_H */

--- a/zebra/zebra_vty.c
+++ b/zebra/zebra_vty.c
@@ -37,6 +37,7 @@
 
 #include "zebra/zebra_router.h"
 #include "zebra/zserv.h"
+#include "zebra/zebra_seg6.h"
 #include "zebra/zebra_vrf.h"
 #include "zebra/zebra_mpls.h"
 #include "zebra/zebra_rnh.h"
@@ -52,6 +53,7 @@
 #include "zebra/ipforward.h"
 #include "zebra/zebra_vxlan_private.h"
 #include "zebra/zebra_pbr.h"
+#include "zebra/ge_netlink.h"
 
 extern int allow_delete;
 
@@ -691,6 +693,22 @@ static void vty_show_ip_route(struct vty *vty, struct route_node *rn,
 						       nexthop->vrf_id));
 			break;
 
+		case NEXTHOP_TYPE_ENCAP:
+		{
+			if (nexthop->nh_seg6_segs && nexthop->nh_seg6_segs->num_segs) {
+				vty_out(vty, " encap seg6 mode %s segs %zd [",
+						nexthop->nh_seg6_mode == INLINE ? "inline" : "encap",
+						nexthop->nh_seg6_segs->num_segs);
+				size_t num_segs = nexthop->nh_seg6_segs->num_segs;
+				for (size_t i=0; i<num_segs; i++ ) {
+					char str[128];
+					inet_ntop(AF_INET6, &nexthop->nh_seg6_segs->segs[i], str, sizeof(str));
+					vty_out(vty, "%s%s", str, i+1<num_segs?" ":"");
+				}
+				vty_out(vty, "]");
+			}
+			break;
+		}
 		case NEXTHOP_TYPE_IFINDEX:
 			vty_out(vty, " is directly connected, %s",
 				ifindex2ifname(nexthop->ifindex,
@@ -2925,6 +2943,154 @@ static int config_write_forwarding(struct vty *vty)
 	return 0;
 }
 
+struct srv6 *srv6_get_default(void)
+{
+	static struct srv6 srv6;
+	static bool first_execution = true;
+	if (first_execution) {
+		srv6.is_enable = false;
+		first_execution = false;
+	}
+	return &srv6;
+}
+
+int srv6_config_write(struct vty *vty)
+{
+	struct srv6 *srv6 = srv6_get_default();
+	if (srv6->is_enable) {
+		vty_out(vty, "segment-routing-ipv6\n");
+		char str[256];
+		inet_ntop(AF_INET6, &srv6->encap_src, str, sizeof(str));
+		vty_out(vty, " encapsulation source-address %s\n", str);
+
+		inet_ntop(AF_INET6, &srv6->locator.prefix, str, sizeof(str));
+		vty_out(vty, " locator default prefix %s/%u\n",
+				str, srv6->locator.prefixlen);
+		vty_out(vty, "!\n");
+	}
+
+	vty_out(vty, "!\n");
+	for (size_t i=0; i<MAX_SEG6LOCAL_SIDS; i++) {
+		if (!seg6local_sids[i])
+			continue;
+		char str[128];
+		snprintf_seg6local_sid(str, sizeof(str), seg6local_sids[i]);
+		vty_out(vty, "%s\n", str);
+	}
+	vty_out(vty, "!\n");
+
+	return 0;
+}
+
+
+DEFUN (no_segment_routing_ipv6,
+       no_segment_routing_ipv6_cmd,
+       "no segment-routing-ipv6",
+			 NO_STR
+       "negate Segment Routing IPv6\n")
+{
+	struct srv6 *srv6 = srv6_get_default();
+	srv6->is_enable = false;
+	return CMD_SUCCESS;
+}
+
+/* "segment-routing-ipv6" commands. */
+DEFUN_NOSH (segment_routing_ipv6,
+       segment_routing_ipv6_cmd,
+       "segment-routing-ipv6",
+       "Segment Routing IPv6\n")
+{
+	struct srv6 *srv6 = srv6_get_default();
+	srv6->is_enable = true;
+	vty->node = SRV6_NODE;
+	return CMD_SUCCESS;
+}
+
+DEFUN (encapsulation_source_address,
+       encapsulation_source_address_cmd,
+       "encapsulation source-address X:X::X:X",
+       "Configure srv6 encapsulation\n"
+			 "Configure srv6 tunnel source address\n"
+			 "Specify source address\n")
+{
+	struct prefix_ipv6 cp;
+	int ret = str2prefix_ipv6(argv[2]->arg, &cp);
+	if (ret <= 0) {
+		vty_out(vty, "%% Malformed address \n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+	assert(cp.prefixlen == 128);
+
+	ge_netlink_sr_tunsrc_change(&cp.prefix);
+
+	struct srv6 *srv6 = srv6_get_default();
+	srv6->is_enable = true;
+	memcpy(&srv6->encap_src, &cp.prefix, sizeof(struct in6_addr));
+	return CMD_SUCCESS;
+}
+
+DEFUN (locator_prefix,
+       locator_prefix_cmd,
+       "locator prefix X:X::X:X/M",
+       "Configure srv6 locator\n"
+			 "Configure srv6 locator prefix\n"
+			 "Specify prefix\n")
+{
+	struct srv6 *srv6 = srv6_get_default();
+	srv6->is_enable = true;
+
+	struct prefix_ipv6 cp;
+	int ret = str2prefix_ipv6(argv[2]->arg, &cp);
+	if (ret <= 0) {
+		vty_out(vty, "%% Malformed address \n");
+		return CMD_WARNING_CONFIG_FAILED;
+	}
+
+	memcpy(&srv6->locator, &cp, sizeof(cp));
+	return CMD_SUCCESS;
+}
+
+DEFUN (show_segment_routing_ipv6,
+       show_segment_routing_ipv6_cmd,
+       "show segment-routing-ipv6",
+       SHOW_STR
+       "Segment-Routing\n")
+{
+	vty_out(vty, "\n");
+	struct srv6 *srv6 = srv6_get_default();
+
+	char str[256];
+	inet_ntop(AF_INET6, &srv6->encap_src, str, sizeof(str));
+	vty_out(vty, "SRv6 Encap Source\n");
+	vty_out(vty, "Name                 ID      Prefix                   Status\n");
+	vty_out(vty, "-------------------- ------- ------------------------ -------\n");
+	vty_out(vty, "default*             1       %-24s Up\n", str);
+	vty_out(vty, "\n");
+
+	prefix2str(&srv6->locator, str, sizeof(str));
+	vty_out(vty, "Locator:\n");
+	vty_out(vty, "Name                 ID      Prefix                   Status\n");
+	vty_out(vty, "-------------------- ------- ------------------------ -------\n");
+	vty_out(vty, "default*             1       %-24s Up\n", str);
+	vty_out(vty, "\n");
+
+	vty_out(vty, "Local SIDs:\n");
+	vty_out(vty, "Name                 ID      Prefix                   Status\n");
+	vty_out(vty, "-------------------- ------- ------------------------ -------\n");
+
+	for (size_t i=0; i<num_seg6local_sids(); i++) {
+		const struct seg6local_sid *sid = seg6local_sids[i];
+		if (!sid) continue;
+		char str[128];
+		inet_ntop(AF_INET6, &sid->sid, str, sizeof(str));
+		vty_out(vty, "%-20s %-7zd %s/%u\n",
+				seg6local_action2str(sid->action), i, str, sid->plen);
+	}
+	vty_out(vty, "\n");
+
+	return CMD_SUCCESS;
+}
+
 DEFUN_HIDDEN (show_frr,
 	      show_frr_cmd,
 	      "show frr",
@@ -2988,6 +3154,9 @@ DEFUN_HIDDEN (show_frr,
 	return CMD_SUCCESS;
 }
 
+/* SRv6 node structure. */
+static struct cmd_node srv6_node = {SRV6_NODE, "%s(config-srv6)# ", 1};
+
 /* IP node for static routes. */
 static struct cmd_node ip_node = {IP_NODE, "", 1};
 static struct cmd_node protocol_node = {PROTOCOL_NODE, "", 1};
@@ -3003,6 +3172,8 @@ static struct cmd_node forwarding_node = {FORWARDING_NODE,
 void zebra_vty_init(void)
 {
 	/* Install configuration write function. */
+	install_node(&srv6_node, srv6_config_write);
+	install_default(SRV6_NODE);
 	install_node(&table_node, config_write_table);
 	install_node(&forwarding_node, config_write_forwarding);
 
@@ -3014,6 +3185,15 @@ void zebra_vty_init(void)
 	install_element(VIEW_NODE, &show_ipv6_forwarding_cmd);
 	install_element(CONFIG_NODE, &ipv6_forwarding_cmd);
 	install_element(CONFIG_NODE, &no_ipv6_forwarding_cmd);
+
+	/* "segment-routing-ipv6" commands. */
+	install_element(CONFIG_NODE, &segment_routing_ipv6_cmd);
+	install_element(CONFIG_NODE, &no_segment_routing_ipv6_cmd);
+	install_element(SRV6_NODE, &encapsulation_source_address_cmd);
+	install_element(SRV6_NODE, &locator_prefix_cmd);
+
+	/* "show segment-routing summary" commands. */
+	install_element(VIEW_NODE, &show_segment_routing_ipv6_cmd);
 
 	/* Route-map */
 	zebra_route_map_init();


### PR DESCRIPTION
本PRは廃止された #1 を分割したものです. BGP SRv6 VPNv4のdplane側のみを抽出しています.

* Support sr tunsrc set/show
* Add seg6 client side
* Add seg6 server side

## 概要


FRR側でバックエンドとして利用しないと行けない部分.
- zebraとしてsrv6をサポートする.
    - [x] rt_netlinkとしてのsrv6に関するフレームワークの追加
        - [x] srv6経路のget/add/del
- bgpdとしてのsrv6のサポートする.
    - [x] sidを経路広告する

- [x] `show segment-routing-ipv6 tunsrc`
- [x] locator

## Test Env

```
./configure \
  --prefix=/usr --includedir=\${prefix}/include \
  --enable-exampledir=\${prefix}/share/doc/frr/examples \
  --bindir=\${prefix}/bin --sbindir=\${prefix}/lib/frr \
  --libdir=\${prefix}/lib/frr --libexecdir=\${prefix}/lib/frr \
  --localstatedir=/var/run/frr --sysconfdir=/etc/frr \
  --with-moduledir=\${prefix}/lib/frr/modules \
  --with-libyang-pluginsdir=\${prefix}/lib/frr/libyang_plugins \
  --enable-configfile-mask=0640 --enable-logfile-mask=0640 \
  --enable-snmp=agentx --enable-multipath=64 --enable-user=frr \
  --enable-group=frr --enable-vty-group=frrvty --with-pkg-git-version \
  --disable-ripd --disable-ripngd --disable-ospfd --disable-ospf6d \
  --disable-ldpd --disable-nhrpd --disable-eigrpd --disable-babeld \
  --disable-isisd --disable-pimd --disable-pbrd --disable-fabricd \
  --disable-vrrpd
```
