### PR TITLE
MP-BGP SRv6 VPNv4 (cplane) 

### DIFF
--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -2870,7 +2870,7 @@ size_t bgp_packet_mpattr_start(struct stream *s, struct peer *peer, afi_t afi,
 	/* Set extended bit always to encode the attribute length as 2 bytes */
 	stream_putc(s, BGP_ATTR_FLAG_OPTIONAL | BGP_ATTR_FLAG_EXTLEN);
 	stream_putc(s, BGP_ATTR_MP_REACH_NLRI);
-	zlog_debug("%s:%05d slankdev stream_putc BGP_ATTR_MP_REACH_NLRI\n", __func__, __LINE__);
+	zlog_debug("%s:%05d slankdev stream_putc BGP_ATTR_MP_REACH_NLRI", __func__, __LINE__);
 	sizep = stream_get_endp(s);
 	stream_putw(s, 0); /* Marker: Attribute length. */
 
@@ -2900,14 +2900,28 @@ size_t bgp_packet_mpattr_start(struct stream *s, struct peer *peer, afi_t afi,
 			stream_put_ipv4(s, attr->nexthop.s_addr);
 			break;
 		case SAFI_MPLS_VPN:
+			{
+			zlog_debug("%s:%d ====================", __func__, __LINE__);
+			zlog_debug("%s:%d SLANK SLANK MPLS-VPN", __func__, __LINE__);
+			zlog_debug("%s:%d ====================", __func__, __LINE__);
 			stream_putc(s, 12);
 			stream_putl(s, 0); /* RD = 0, per RFC */
 			stream_putl(s, 0);
 			stream_put(s, &attr->mp_nexthop_global_in, 4);
+
+			char str[128], str2[128];
+			inet_ntop(AF_INET, &attr->mp_nexthop_global_in, str, sizeof(str));
+			inet_ntop(AF_INET, &attr->nexthop, str2, sizeof(str2));
+			zlog_debug("%s:%d [mp_nexthop_global_in -> %s]", __func__, __LINE__, str);
+			zlog_debug("%s:%d [nexthop -> %s]", __func__, __LINE__, str2);
 			break;
+		}
 
 		//TODO: (slankdev)
 		case SAFI_SRV6_VPN:
+			zlog_debug("%s:%d ====================", __func__, __LINE__);
+			zlog_debug("%s:%d SLANK SLANK SRV6-VPN", __func__, __LINE__);
+			zlog_debug("%s:%d ====================", __func__, __LINE__);
 			stream_putc(s, 12);
 			stream_putl(s, 0); /* RD = 0, per RFC */
 			stream_putl(s, 0);
@@ -3167,6 +3181,7 @@ bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer,
 				mpls_label_t *label, uint32_t num_labels,
 				int addpath_encode, uint32_t addpath_tx_id)
 {
+	zlog_debug("%s:%d slankdev afi/safi=%d/%d", __func__, __LINE__, afi, safi);
 	size_t cp;
 	size_t aspath_sizep;
 	struct aspath *aspath;
@@ -3185,6 +3200,8 @@ bgp_size_t bgp_packet_attribute(struct bgp *bgp, struct peer *peer,
 		 && !peer_cap_enhe(peer, afi, safi))) {
 		size_t mpattrlen_pos = 0;
 
+
+		zlog_debug("%s:%05d slankdev before bgp_packet_mpattr_start()", __func__, __LINE__);
 		mpattrlen_pos = bgp_packet_mpattr_start(s, peer, afi, safi,
 							vecarr, attr);
 		bgp_packet_mpattr_prefix(s, afi, safi, p, prd, label,

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -2900,22 +2900,11 @@ size_t bgp_packet_mpattr_start(struct stream *s, struct peer *peer, afi_t afi,
 			stream_put_ipv4(s, attr->nexthop.s_addr);
 			break;
 		case SAFI_MPLS_VPN:
-			{
-			zlog_debug("%s:%d ====================", __func__, __LINE__);
-			zlog_debug("%s:%d SLANK SLANK MPLS-VPN", __func__, __LINE__);
-			zlog_debug("%s:%d ====================", __func__, __LINE__);
 			stream_putc(s, 12);
 			stream_putl(s, 0); /* RD = 0, per RFC */
 			stream_putl(s, 0);
 			stream_put(s, &attr->mp_nexthop_global_in, 4);
-
-			char str[128], str2[128];
-			inet_ntop(AF_INET, &attr->mp_nexthop_global_in, str, sizeof(str));
-			inet_ntop(AF_INET, &attr->nexthop, str2, sizeof(str2));
-			zlog_debug("%s:%d [mp_nexthop_global_in -> %s]", __func__, __LINE__, str);
-			zlog_debug("%s:%d [nexthop -> %s]", __func__, __LINE__, str2);
 			break;
-		}
 
 		//TODO: (slankdev)
 		case SAFI_SRV6_VPN:

--- a/bgpd/bgp_attr.c
+++ b/bgpd/bgp_attr.c
@@ -2870,6 +2870,7 @@ size_t bgp_packet_mpattr_start(struct stream *s, struct peer *peer, afi_t afi,
 	/* Set extended bit always to encode the attribute length as 2 bytes */
 	stream_putc(s, BGP_ATTR_FLAG_OPTIONAL | BGP_ATTR_FLAG_EXTLEN);
 	stream_putc(s, BGP_ATTR_MP_REACH_NLRI);
+	zlog_debug("%s:%05d slankdev stream_putc BGP_ATTR_MP_REACH_NLRI\n", __func__, __LINE__);
 	sizep = stream_get_endp(s);
 	stream_putw(s, 0); /* Marker: Attribute length. */
 
@@ -2904,6 +2905,15 @@ size_t bgp_packet_mpattr_start(struct stream *s, struct peer *peer, afi_t afi,
 			stream_putl(s, 0);
 			stream_put(s, &attr->mp_nexthop_global_in, 4);
 			break;
+
+		//TODO: (slankdev)
+		case SAFI_SRV6_VPN:
+			stream_putc(s, 12);
+			stream_putl(s, 0); /* RD = 0, per RFC */
+			stream_putl(s, 0);
+			stream_put(s, &attr->mp_nexthop_global_in, 4);
+			break;
+
 		case SAFI_ENCAP:
 		case SAFI_EVPN:
 			stream_putc(s, 4);

--- a/bgpd/bgp_encap_types.h
+++ b/bgpd/bgp_encap_types.h
@@ -39,7 +39,8 @@ typedef enum {
 	BGP_ENCAP_TYPE_MPLS_IN_GRE = 11,
 	BGP_ENCAP_TYPE_VXLAN_GPE = 12,
 	BGP_ENCAP_TYPE_MPLS_IN_UDP = 13,
-	BGP_ENCAP_TYPE_PBB
+	BGP_ENCAP_TYPE_PBB,
+	BGP_ENCAP_TYPE_SRV6 = 17,
 } bgp_encap_types;
 
 typedef enum {

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -467,7 +467,7 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 	    struct bgp *bgp_orig, struct prefix *nexthop_orig,
 	    int nexthop_self_flag, int debug)
 {
-	zlog_debug("%s:%d slankdev", __func__, __LINE__);
+	zlog_debug("%s:%d slankdev afi/safi=%d/%d", __func__, __LINE__, afi, safi);
 	struct prefix *p = &bn->p;
 	struct bgp_path_info *bpi;
 	struct bgp_path_info *bpi_ultimate;
@@ -476,7 +476,7 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 
 	if (debug) {
 		prefix2str(&bn->p, buf_prefix, sizeof(buf_prefix));
-		zlog_debug("%s: entry: leak-to=%s, p=%s, type=%d, sub_type=%d",
+		zlog_debug("%s: entry: leak-to=%s, p=%s, type=%d, sub_type=%d slankdev",
 			   __func__, bgp->name_pretty, buf_prefix,
 			   source_bpi->type, source_bpi->sub_type);
 	}
@@ -518,7 +518,7 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 			bgp_attr_unintern(&new_attr);
 			if (debug)
 				zlog_debug(
-					"%s: ->%s: %s: Found route, no change",
+					"%s: ->%s: %s: Found route, no change. slankdev",
 					__func__, bgp->name_pretty,
 					buf_prefix);
 			return NULL;
@@ -567,7 +567,7 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 							   afi, bpi, NULL, 0);
 
 		if (debug)
-			zlog_debug("%s: nexthop is %svalid (in vrf %s)",
+			zlog_debug("%s: nexthop is %svalid (in vrf %s) slankdev",
 				__func__, (nh_valid ? "" : "not "),
 				bgp_nexthop->name_pretty);
 
@@ -580,7 +580,7 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 		bgp_unlock_node(bn);
 
 		if (debug)
-			zlog_debug("%s: ->%s: %s Found route, changed attr",
+			zlog_debug("%s: ->%s: %s Found route, changed attr slankdev",
 				   __func__, bgp->name_pretty, buf_prefix);
 
 		return bpi;
@@ -632,7 +632,7 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 						afi, new, NULL, 0);
 
 	if (debug)
-		zlog_debug("%s: nexthop is %svalid (in vrf %s)",
+		zlog_debug("%s: nexthop is %svalid (in vrf %s) slankdev",
 			__func__, (nh_valid ? "" : "not "),
 			bgp_nexthop->name_pretty);
 	if (nh_valid)
@@ -645,7 +645,7 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 	bgp_process(bgp, bn, afi, safi);
 
 	if (debug)
-		zlog_debug("%s: ->%s: %s: Added new route", __func__,
+		zlog_debug("%s: ->%s: %s: Added new route. slankdev", __func__,
 			   bgp->name_pretty, buf_prefix);
 
 	return new;
@@ -656,6 +656,7 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 			      struct bgp *bgp_vrf,	    /* from */
 			      struct bgp_path_info *path_vrf) /* route */
 {
+	zlog_debug("%s:%d slankdev", __func__, __LINE__);
 	int debug = BGP_DEBUG(vpn, VPN_LEAK_FROM_VRF);
 	struct prefix *p = &path_vrf->net->p;
 	afi_t afi = family2afi(p->family);
@@ -669,13 +670,13 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 	int nexthop_self_flag = 0;
 
 	if (debug)
-		zlog_debug("%s: from vrf %s", __func__, bgp_vrf->name_pretty);
+		zlog_debug("%s: from vrf %s. slankdev", __func__, bgp_vrf->name_pretty);
 
 	if (debug && path_vrf->attr->ecommunity) {
 		char *s = ecommunity_ecom2str(path_vrf->attr->ecommunity,
 					      ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
 
-		zlog_debug("%s: %s path_vrf->type=%d, EC{%s}", __func__,
+		zlog_debug("%s: %s path_vrf->type=%d, EC{%s}. slankdev", __func__,
 			   bgp_vrf->name, path_vrf->type, s);
 		XFREE(MTYPE_ECOMMUNITY_STR, s);
 	}
@@ -685,7 +686,7 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 
 	if (!afi) {
 		if (debug)
-			zlog_debug("%s: can't get afi of prefix", __func__);
+			zlog_debug("%s: can't get afi of prefix. slankdev", __func__);
 		return;
 	}
 
@@ -695,9 +696,9 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 
 	if (!vpn_leak_to_vpn_active(bgp_vrf, afi, &debugmsg)) {
 		if (debug)
-			zlog_debug("%s: %s skipping: %s", __func__,
+			zlog_debug("%s: %s skipping: %s [slankdev10293]", __func__,
 				   bgp_vrf->name, debugmsg);
-		return;
+		return; //slankdev
 	}
 
 	bgp_attr_dup(&static_attr, path_vrf->attr); /* shallow copy */
@@ -719,7 +720,7 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 			bgp_attr_flush(&static_attr); /* free any added parts */
 			if (debug)
 				zlog_debug(
-					"%s: vrf %s route map \"%s\" says DENY, returning",
+					"%s: vrf %s route map \"%s\" says DENY, returning. slankdev",
 					__func__, bgp_vrf->name_pretty,
 					bgp_vrf->vpn_policy[afi]
 						.rmap[BGP_VPN_POLICY_DIR_TOVPN]
@@ -732,7 +733,7 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 		char *s = ecommunity_ecom2str(static_attr.ecommunity,
 					      ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
 
-		zlog_debug("%s: post route map static_attr.ecommunity{%s}",
+		zlog_debug("%s: post route map static_attr.ecommunity{%s}. slankdev",
 			   __func__, s);
 		XFREE(MTYPE_ECOMMUNITY_STR, s);
 	}
@@ -763,7 +764,7 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 		char *s = ecommunity_ecom2str(static_attr.ecommunity,
 					      ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
 
-		zlog_debug("%s: post merge static_attr.ecommunity{%s}",
+		zlog_debug("%s: post merge static_attr.ecommunity{%s}. slankdev",
 			   __func__, s);
 		XFREE(MTYPE_ECOMMUNITY_STR, s);
 	}
@@ -852,7 +853,7 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 		char *s = ecommunity_ecom2str(new_attr->ecommunity,
 					      ECOMMUNITY_FORMAT_ROUTE_MAP, 0);
 
-		zlog_debug("%s: new_attr->ecommunity{%s}", __func__, s);
+		zlog_debug("%s: new_attr->ecommunity{%s}. slankdev", __func__, s);
 		XFREE(MTYPE_ECOMMUNITY_STR, s);
 	}
 
@@ -863,6 +864,8 @@ void vpn_leak_from_vrf_update(struct bgp *bgp_vpn,	    /* to */
 
 	struct bgp_path_info *new_info;
 
+
+	zlog_debug("%s:%d slankdev afi/safi=%d/%d", __func__, __LINE__, afi, safi);
 	new_info = leak_update(bgp_vpn, bn, new_attr, afi, safi, path_vrf,
 			       &label, 1, path_vrf, bgp_vrf, NULL,
 			       nexthop_self_flag, debug);
@@ -1033,6 +1036,7 @@ void vpn_leak_from_vrf_update_all(struct bgp *bgp_vpn, /* to */
 				zlog_debug(
 					"%s: calling vpn_leak_from_vrf_update",
 					__func__);
+			zlog_debug("%s:%d slankdev before vpn_leak_from_vrf_update()", __func__, __LINE__);
 			vpn_leak_from_vrf_update(bgp_vpn, bgp_vrf, bpi);
 		}
 	}
@@ -1223,6 +1227,7 @@ vpn_leak_to_vrf_update_onevrf(struct bgp *bgp_vrf,	    /* to */
 	else
 		src_vrf = bgp_vpn;
 
+	zlog_debug("%s:%d slankdev afi/safi=%d/%d", __func__, __LINE__, afi, safi);
 	leak_update(bgp_vrf, bn, new_attr, afi, safi, path_vpn, pLabels,
 		    num_labels, path_vpn, /* parent */
 		    src_vrf, &nexthop_orig, nexthop_self_flag, debug);

--- a/bgpd/bgp_mplsvpn.c
+++ b/bgpd/bgp_mplsvpn.c
@@ -467,6 +467,7 @@ leak_update(struct bgp *bgp, /* destination bgp instance */
 	    struct bgp *bgp_orig, struct prefix *nexthop_orig,
 	    int nexthop_self_flag, int debug)
 {
+	zlog_debug("%s:%d slankdev", __func__, __LINE__);
 	struct prefix *p = &bn->p;
 	struct bgp_path_info *bpi;
 	struct bgp_path_info *bpi_ultimate;

--- a/bgpd/bgp_srv6vpn.h
+++ b/bgpd/bgp_srv6vpn.h
@@ -1,0 +1,23 @@
+/* SRv6-VPN
+ * Copyright (C) 2019 Hiroki Shirokura <slank.dev@gmail.com>
+ *
+ * This file is part of GxNU Zebra.
+ *
+ * GNU Zebra is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation; either version 2, or (at your option) any
+ * later version.
+ *
+ * GNU Zebra is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; see the file COPYING; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA
+ */
+#ifndef _QUAGGA_BGP_SRV6VPN_H
+#define _QUAGGA_BGP_SRV6VPN_H
+
+#endif /* _QUAGGA_BGP_SRV6VPN_H */

--- a/bgpd/bgp_updgrp_packet.c
+++ b/bgpd/bgp_updgrp_packet.c
@@ -689,6 +689,7 @@ int subgroup_packets_to_build(struct update_subgroup *subgrp)
 /* Make BGP update packet.  */
 struct bpacket *subgroup_update_packet(struct update_subgroup *subgrp)
 {
+	//zlog_debug("%s:%d slankdev", __func__, __LINE__);
 	struct bpacket_attr_vec_arr vecarr;
 	struct bpacket *pkt;
 	struct peer *peer;
@@ -841,10 +842,12 @@ struct bpacket *subgroup_update_packet(struct update_subgroup *subgrp)
 				num_labels = path->extra->num_labels;
 			}
 
-			if (stream_empty(snlri))
+			if (stream_empty(snlri)) {
+				zlog_debug("%s:%05d slankdev before bgp_packet_mpattr_start()", __func__, __LINE__);
 				mpattrlen_pos = bgp_packet_mpattr_start(
 					snlri, peer, afi, safi, &vecarr,
 					adv->baa->attr);
+			}
 
 			bgp_packet_mpattr_prefix(snlri, afi, safi, &rn->p, prd,
 						 label_pnt, num_labels,

--- a/bgpd/bgp_vty.h
+++ b/bgpd/bgp_vty.h
@@ -36,8 +36,9 @@ struct bgp;
 #define BGP_AFI_SAFI_CMD_STR    BGP_AFI_CMD_STR" "BGP_SAFI_CMD_STR
 #define BGP_AFI_SAFI_HELP_STR   BGP_AFI_HELP_STR BGP_SAFI_HELP_STR
 
-#define BGP_SAFI_WITH_LABEL_CMD_STR  "<unicast|multicast|vpn|labeled-unicast|flowspec>"
+#define BGP_SAFI_WITH_LABEL_CMD_STR  "<unicast|multicast|vpn|labeled-unicast|flowspec|srv6-vpn>"
 #define BGP_SAFI_WITH_LABEL_HELP_STR                                           \
+	"Address Family modifier\n"                                            \
 	"Address Family modifier\n"                                            \
 	"Address Family modifier\n"                                            \
 	"Address Family modifier\n"                                            \

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7454,6 +7454,8 @@ static void bgp_config_write_family(struct vty *vty, struct bgp *bgp, afi_t afi,
 			vty_frame(vty, "ipv4 encap");
 		else if (safi == SAFI_FLOWSPEC)
 			vty_frame(vty, "ipv4 flowspec");
+		else if (safi == SAFI_SRV6_VPN)
+			vty_frame(vty, "ipv4 srv6-vpn");
 	} else if (afi == AFI_IP6) {
 		if (safi == SAFI_UNICAST)
 			vty_frame(vty, "ipv6 unicast");
@@ -7811,6 +7813,9 @@ int bgp_config_write(struct vty *vty)
 
 		/* EVPN configuration.  */
 		bgp_config_write_family(vty, bgp, AFI_L2VPN, SAFI_EVPN);
+
+		/* IPv4 SRv6-VPN configuration.  */
+		bgp_config_write_family(vty, bgp, AFI_IP, SAFI_SRV6_VPN);
 
 		hook_call(bgp_inst_config_write, bgp, vty);
 

--- a/bgpd/bgpd.c
+++ b/bgpd/bgpd.c
@@ -7515,6 +7515,12 @@ static void bgp_config_write_family(struct vty *vty, struct bgp *bgp, afi_t afi,
 
 			vty_out(vty, "  import vpn\n");
 		}
+		if (CHECK_FLAG(bgp->af_flags[afi][safi], BGP_CONFIG_VRF_TO_SRV6VPN_EXPORT)) {
+			vty_out(vty, "  export srv6-vpn\n");
+		}
+		if (CHECK_FLAG(bgp->af_flags[afi][safi], BGP_CONFIG_SRV6VPN_TO_VRF_IMPORT)) {
+			vty_out(vty, "  import srv6-vpn\n");
+		}
 		if (CHECK_FLAG(bgp->af_flags[afi][safi],
 			       BGP_CONFIG_VRF_TO_VRF_IMPORT)) {
 			char *name;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -92,6 +92,7 @@ enum bgp_af_index {
 	BGP_AF_IPV6_LBL_UNICAST,
 	BGP_AF_IPV4_FLOWSPEC,
 	BGP_AF_IPV6_FLOWSPEC,
+	BGP_AF_IPV4_SRV6_VPN,
 	BGP_AF_MAX
 };
 
@@ -1785,6 +1786,8 @@ static inline int afindex(afi_t afi, safi_t safi)
 			break;
 		case SAFI_FLOWSPEC:
 			return BGP_AF_IPV4_FLOWSPEC;
+		case SAFI_SRV6_VPN:
+			return BGP_AF_IPV4_SRV6_VPN;
 		default:
 			return BGP_AF_MAX;
 			break;

--- a/bgpd/bgpd.h
+++ b/bgpd/bgpd.h
@@ -381,6 +381,9 @@ struct bgp {
 #define BGP_CONFIG_VRF_TO_VRF_IMPORT			(1 << 7)
 #define BGP_CONFIG_VRF_TO_VRF_EXPORT			(1 << 8)
 
+#define BGP_CONFIG_VRF_TO_SRV6VPN_EXPORT		(1 << 9)
+#define BGP_CONFIG_SRV6VPN_TO_VRF_IMPORT		(1 << 10)
+
 	/* BGP per AF peer count */
 	uint32_t af_peer_count[AFI_MAX][SAFI_MAX];
 

--- a/bgpd/subdir.am
+++ b/bgpd/subdir.am
@@ -18,6 +18,7 @@ vtysh_scan += \
 	$(top_srcdir)/bgpd/bgp_evpn_vty.c \
 	$(top_srcdir)/bgpd/bgp_filter.c \
 	$(top_srcdir)/bgpd/bgp_mplsvpn.c \
+	$(top_srcdir)/bgpd/bgp_srv6vpn.c \
 	$(top_srcdir)/bgpd/bgp_nexthop.c \
 	$(top_srcdir)/bgpd/bgp_route.c \
 	$(top_srcdir)/bgpd/bgp_routemap.c \
@@ -80,6 +81,7 @@ bgpd_libbgp_a_SOURCES = \
 	bgpd/bgp_memory.c \
 	bgpd/bgp_mpath.c \
 	bgpd/bgp_mplsvpn.c \
+	bgpd/bgp_srv6vpn.c \
 	bgpd/bgp_network.c \
 	bgpd/bgp_nexthop.c \
 	bgpd/bgp_nht.c \
@@ -155,6 +157,7 @@ noinst_HEADERS += \
 	bgpd/bgp_memory.h \
 	bgpd/bgp_mpath.h \
 	bgpd/bgp_mplsvpn.h \
+	bgpd/bgp_srv6vpn.h \
 	bgpd/bgp_network.h \
 	bgpd/bgp_nexthop.h \
 	bgpd/bgp_nht.h \

--- a/lib/command.c
+++ b/lib/command.c
@@ -114,6 +114,7 @@ const char *node_names[] = {
 	"bgp vnc l2",		    // BGP_VNC_L2_GROUP_NODE,
 	"rfp defaults",		    // RFP_DEFAULTS_NODE,
 	"bgp evpn",		    // BGP_EVPN_NODE,
+	"bgp srv6 vpnv4",		    // BGP_SRV6_VPNV4_NODE,
 	"ospf",			    // OSPF_NODE,
 	"ospf6",		    // OSPF6_NODE,
 	"ldp",			    // LDP_NODE,
@@ -978,6 +979,7 @@ enum node_type node_parent(enum node_type node)
 	case BGP_EVPN_NODE:
 	case BGP_IPV6L_NODE:
 	case BMP_NODE:
+	case BGP_SRV6_VPNV4_NODE:
 		ret = BGP_NODE;
 		break;
 	case BGP_EVPN_VNI_NODE:
@@ -1497,6 +1499,7 @@ void cmd_exit(struct vty *vty)
 	case BGP_EVPN_NODE:
 	case BGP_IPV6L_NODE:
 	case BMP_NODE:
+	case BGP_SRV6_VPNV4_NODE:
 		vty->node = BGP_NODE;
 		break;
 	case BGP_EVPN_VNI_NODE:

--- a/lib/command.h
+++ b/lib/command.h
@@ -161,6 +161,7 @@ enum node_type {
 	VRRP_NODE,		 /* VRRP node */
 	BMP_NODE,		/* BMP config under router bgp */
 	SRV6_NODE,   /* SRv6 config */
+	BGP_SRV6_VPNV4_NODE,		 /* BGP SRv6-VPN PE exchange. */
 	NODE_TYPE_MAX, /* maximum */
 };
 

--- a/lib/iana_afi.h
+++ b/lib/iana_afi.h
@@ -44,6 +44,7 @@ typedef enum {
 	IANA_SAFI_LABELED_UNICAST = 4,
 	IANA_SAFI_ENCAP = 7,
 	IANA_SAFI_EVPN = 70,
+	IANA_SAFI_SRV6_VPN = 99,
 	IANA_SAFI_MPLS_VPN = 128,
 	IANA_SAFI_FLOWSPEC = 133
 } iana_safi_t;
@@ -98,6 +99,8 @@ static inline safi_t safi_iana2int(iana_safi_t safi)
 		return SAFI_LABELED_UNICAST;
 	case IANA_SAFI_FLOWSPEC:
 		return SAFI_FLOWSPEC;
+	case IANA_SAFI_SRV6_VPN:
+		return SAFI_SRV6_VPN;
 	default:
 		return SAFI_MAX;
 	}
@@ -120,6 +123,8 @@ static inline iana_safi_t safi_int2iana(safi_t safi)
 		return IANA_SAFI_LABELED_UNICAST;
 	case SAFI_FLOWSPEC:
 		return IANA_SAFI_FLOWSPEC;
+	case SAFI_SRV6_VPN:
+		return IANA_SAFI_SRV6_VPN;
 	default:
 		return IANA_SAFI_RESERVED;
 	}

--- a/lib/zebra.h
+++ b/lib/zebra.h
@@ -369,7 +369,8 @@ typedef enum {
 	SAFI_EVPN = 5,
 	SAFI_LABELED_UNICAST = 6,
 	SAFI_FLOWSPEC = 7,
-	SAFI_MAX = 8
+	SAFI_SRV6_VPN = 8,
+	SAFI_MAX = 9
 } safi_t;
 
 /* Default Administrative Distance of each protocol. */

--- a/vtysh/vtysh.c
+++ b/vtysh/vtysh.c
@@ -517,6 +517,7 @@ static int vtysh_execute_func(const char *line, int pager)
 		     || saved_node == BGP_IPV6L_NODE
 		     || saved_node == BGP_IPV6M_NODE
 		     || saved_node == BGP_EVPN_NODE
+				 || saved_node == BGP_SRV6_VPNV4_NODE
 		     || saved_node == LDP_IPV4_NODE
 		     || saved_node == LDP_IPV6_NODE)
 		    && (tried == 1)) {
@@ -800,7 +801,8 @@ int vtysh_mark_file(const char *filename)
 			     || prev_node == BGP_IPV6L_NODE
 			     || prev_node == BGP_IPV4M_NODE
 			     || prev_node == BGP_IPV6M_NODE
-			     || prev_node == BGP_EVPN_NODE)
+			     || prev_node == BGP_EVPN_NODE
+			     || prev_node == BGP_SRV6_VPNV4_NODE)
 			    && (tried == 1)) {
 				vty_out(vty, "exit-address-family\n");
 			} else if ((prev_node == BGP_EVPN_VNI_NODE)
@@ -1252,6 +1254,9 @@ static struct cmd_node bgp_evpn_vni_node = {BGP_EVPN_VNI_NODE,
 static struct cmd_node bgp_ipv6l_node = {BGP_IPV6L_NODE,
 					 "%s(config-router-af)# "};
 
+static struct cmd_node bgp_srv6_vpnv4_node = {BGP_SRV6_VPNV4_NODE,
+					 "%s(config-router-af)# "};
+
 static struct cmd_node bgp_vnc_defaults_node = {
 	BGP_VNC_DEFAULTS_NODE, "%s(config-router-vnc-defaults)# "};
 
@@ -1427,6 +1432,16 @@ DEFUNSH(VTYSH_BGPD, address_family_ipv4_vpn, address_family_ipv4_vpn_cmd,
 	"Address Family modifier\n")
 {
 	vty->node = BGP_VPNV4_NODE;
+	return CMD_SUCCESS;
+}
+
+DEFUNSH(VTYSH_BGPD, address_family_ipv4_srv6_vpn, address_family_ipv4_srv6_vpn_cmd,
+	"address-family ipv4 srv6-vpn",
+	"Enter Address Family command mode\n"
+	"Address Family\n"
+	"Address Family modifier\n")
+{
+	vty->node = BGP_SRV6_VPNV4_NODE;
 	return CMD_SUCCESS;
 }
 
@@ -1867,6 +1882,7 @@ static int vtysh_exit(struct vty *vty)
 	case BGP_FLOWSPECV6_NODE:
 	case BGP_VRF_POLICY_NODE:
 	case BGP_EVPN_NODE:
+	case BGP_SRV6_VPNV4_NODE:
 	case BGP_VNC_DEFAULTS_NODE:
 	case BGP_VNC_NVE_GROUP_NODE:
 	case BGP_VNC_L2_GROUP_NODE:
@@ -1925,7 +1941,8 @@ DEFUNSH(VTYSH_BGPD, exit_address_family, exit_address_family_cmd,
 	    || vty->node == BGP_IPV6L_NODE || vty->node == BGP_IPV6M_NODE
 	    || vty->node == BGP_EVPN_NODE
 	    || vty->node == BGP_FLOWSPECV4_NODE
-	    || vty->node == BGP_FLOWSPECV6_NODE)
+	    || vty->node == BGP_FLOWSPECV6_NODE
+	    || vty->node == BGP_SRV6_VPNV4_NODE)
 		vty->node = BGP_NODE;
 	return CMD_SUCCESS;
 }
@@ -3750,6 +3767,7 @@ void vtysh_init_vty(void)
 	install_node(&bgp_vrf_policy_node, NULL);
 	install_node(&bgp_evpn_node, NULL);
 	install_node(&bgp_evpn_vni_node, NULL);
+	install_node(&bgp_srv6_vpnv4_node, NULL);
 	install_node(&bgp_vnc_defaults_node, NULL);
 	install_node(&bgp_vnc_nve_group_node, NULL);
 	install_node(&bgp_vnc_l2_group_node, NULL);
@@ -3848,6 +3866,8 @@ void vtysh_init_vty(void)
 	install_element(BGP_EVPN_NODE, &vtysh_exit_bgpd_cmd);
 	install_element(BGP_EVPN_VNI_NODE, &vtysh_exit_bgpd_cmd);
 	install_element(BGP_EVPN_VNI_NODE, &vtysh_quit_bgpd_cmd);
+	install_element(BGP_SRV6_VPNV4_NODE, &vtysh_exit_bgpd_cmd);
+	install_element(BGP_SRV6_VPNV4_NODE, &vtysh_quit_bgpd_cmd);
 	install_element(BGP_IPV6L_NODE, &vtysh_exit_bgpd_cmd);
 	install_element(BGP_IPV6L_NODE, &vtysh_quit_bgpd_cmd);
 #if defined(ENABLE_BGP_VNC)
@@ -3920,6 +3940,7 @@ void vtysh_init_vty(void)
 	install_element(BGP_VRF_POLICY_NODE, &vtysh_end_all_cmd);
 	install_element(BGP_EVPN_NODE, &vtysh_end_all_cmd);
 	install_element(BGP_EVPN_VNI_NODE, &vtysh_end_all_cmd);
+	install_element(BGP_SRV6_VPNV4_NODE, &vtysh_end_all_cmd);
 	install_element(BGP_VNC_DEFAULTS_NODE, &vtysh_end_all_cmd);
 	install_element(BGP_VNC_NVE_GROUP_NODE, &vtysh_end_all_cmd);
 	install_element(BGP_VNC_L2_GROUP_NODE, &vtysh_end_all_cmd);
@@ -3991,6 +4012,7 @@ void vtysh_init_vty(void)
 	install_element(BGP_NODE, &address_family_evpn_cmd);
 	install_element(BGP_NODE, &address_family_flowspecv4_cmd);
 	install_element(BGP_NODE, &address_family_flowspecv6_cmd);
+	install_element(BGP_NODE, &address_family_ipv4_srv6_vpn_cmd);
 #if defined(HAVE_CUMULUS)
 	install_element(BGP_NODE, &address_family_evpn2_cmd);
 #endif
@@ -4005,6 +4027,7 @@ void vtysh_init_vty(void)
 	install_element(BGP_IPV6L_NODE, &exit_address_family_cmd);
 	install_element(BGP_FLOWSPECV4_NODE, &exit_address_family_cmd);
 	install_element(BGP_FLOWSPECV6_NODE, &exit_address_family_cmd);
+	install_element(BGP_SRV6_VPNV4_NODE, &exit_address_family_cmd);
 
 	install_element(BGP_NODE, &bmp_targets_cmd);
 	install_element(BMP_NODE, &bmp_exit_cmd);


### PR DESCRIPTION
本PRは廃止された #1 を分割したものです. BGP SRv6 VPNv4のdplane側のみを抽出しています.